### PR TITLE
drop renaming of zone id

### DIFF
--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -700,7 +700,7 @@ def travel_model_output(parcels, households, jobs, buildings,
     # jobs and the one called zone_id has null values while there others do not
     # going to change this while I think about this - turns out this has to do
     # with major caching issue which has been reported upstream
-    jobs_df["zone_id"] = jobs_df.zone_id_x
+    # jobs_df["zone_id"] = jobs_df.zone_id_x
 
     def getsectorcounts(sector):
         return jobs_df.query("empsix == '%s'" % sector).\


### PR DESCRIPTION
this crashes and @conorhenley said he has been commenting it out. @fscottfoti  can we drop this line because the problem in orca has now been fixed? and all the comments above it? or?