### PR TITLE
Command line flag to set a random seed

### DIFF
--- a/baus.py
+++ b/baus.py
@@ -7,6 +7,7 @@ from baus import slr
 from baus import earthquake
 from baus import ual
 from baus import validation
+import numpy as np
 import pandas as pd
 import orca
 import socket
@@ -15,6 +16,9 @@ import warnings
 from baus.utils import compare_summary
 
 warnings.filterwarnings("ignore")
+
+# Set random seed
+np.random.seed(12)
 
 # Suppress scientific notation in pandas output
 pd.set_option('display.float_format', lambda x: '%.3f' % x)

--- a/baus.py
+++ b/baus.py
@@ -17,14 +17,12 @@ from baus.utils import compare_summary
 
 warnings.filterwarnings("ignore")
 
-# Set random seed
-np.random.seed(12)
-
 # Suppress scientific notation in pandas output
 pd.set_option('display.float_format', lambda x: '%.3f' % x)
 
 SLACK = MAPS = "URBANSIM_SLACK" in os.environ
 LOGS = True
+RANDOM_SEED = False
 INTERACT = False
 SCENARIO = None
 MODE = "simulation"
@@ -70,6 +68,9 @@ parser.add_argument('-y', action='store', dest='out_year', type=int,
 parser.add_argument('--mode', action='store', dest='mode',
                     help='which mode to run (see code for mode options)')
 
+parser.add_argument('--random-seed', action='store_true', dest='random_seed',
+                    help='set a random seed for consistent stochastic output')
+
 parser.add_argument('--disable-slack', action='store_true', dest='noslack',
                     help='disable slack outputs')
 
@@ -93,6 +94,9 @@ SKIP_BASE_YEAR = options.skip_base_year
 if options.mode:
     MODE = options.mode
 
+if options.random_seed:
+    RANDOM_SEED = True
+
 if options.noslack:
     SLACK = False
 
@@ -109,6 +113,9 @@ if LOGS:
     print '***The Standard stream is being written to /runs/run{0}.log***'\
         .format(run_num)
     sys.stdout = sys.stderr = open("runs/run%d.log" % run_num, 'w')
+
+if RANDOM_SEED:
+    np.random.seed(12)
 
 if SLACK:
     from slacker import Slacker


### PR DESCRIPTION
This PR adds an optional command line flag to `baus.py` for setting a random seed before invoking the model logic. 

For a given simulation (i.e. the same steps with the same input), this will produce identical stochastic output each time it's run.


### Usage

The command line flag is `--random-seed`. It can be used in any context and does not take an argument.

Example:

`python baus.py -c --random-seed`


### Testing

This was tested using the following procedure:

1. Run simulation without a random seed, and save the `runXX_taz_summaries_2010.csv` output file

   `python baus.py -c -y 2010`

2. Run with a random seed, saving the same output file

   `python baus.py -c -y 2010 --random-seed`

3. Run with a random seed a second time

   `python baus.py -c -y 2010 --random-seed`

4. Perform a diff on the three output files. The latter two should be identical, while the first should have many differences in its numerical values.