### PR TITLE
Bug fixes to support NumPy 1.16

### DIFF
--- a/baus/models.py
+++ b/baus/models.py
@@ -119,7 +119,16 @@ def _proportional_jobs_model(
     # city but not locations to put them in.  we need to drop this demand
     drop = need_more_jobs.index.difference(locations_series.unique())
     print "We don't have any locations for these locations:\n", drop
-    need_more_jobs = need_more_jobs.drop(drop)
+    
+    print "TEMP INSTRUMENTING"
+    print type(need_more_jobs)
+    print type(drop)
+    print type(need_more_jobs.drop(drop))
+    print need_more_jobs
+    print drop
+    print need_more_jobs.drop(drop)
+    
+    need_more_jobs = need_more_jobs.drop(drop).astype('int')
 
     # choose random locations within jurises to match need_more_jobs totals
     choices = groupby_random_choice(locations_series, need_more_jobs,
@@ -511,6 +520,10 @@ def residential_developer(feasibility, households, buildings, parcels, year,
         # method below
         buildings = orca.get_table('buildings')
 
+        print "TEMP INSTRUMENTING"
+        print type(target)
+        print target
+
         new_buildings = utils.run_developer(
             "residential",
             households,
@@ -523,7 +536,7 @@ def residential_developer(feasibility, households, buildings, parcels, year,
             year=year,
             form_to_btype_callback=form_to_btype_func,
             add_more_columns_callback=add_extra_columns_func,
-            num_units_to_build=target,
+            num_units_to_build=int(target),
             profit_to_prob_func=subsidies.profit_to_prob_func,
             **kwargs)
 
@@ -718,6 +731,10 @@ def office_developer(feasibility, jobs, buildings, parcels, year,
             # method below
             buildings = orca.get_table('buildings')
 
+            print "TEMP INSTRUMENTING"
+            print type(target)
+            print target
+
             new_buildings = utils.run_developer(
                 typ.lower(),
                 jobs,
@@ -731,7 +748,7 @@ def office_developer(feasibility, jobs, buildings, parcels, year,
                 form_to_btype_callback=form_to_btype_func,
                 add_more_columns_callback=add_extra_columns_func,
                 residential=False,
-                num_units_to_build=target,
+                num_units_to_build=int(target),
                 profit_to_prob_func=subsidies.profit_to_prob_func,
                 **dev_settings['kwargs'])
 

--- a/baus/models.py
+++ b/baus/models.py
@@ -119,15 +119,6 @@ def _proportional_jobs_model(
     # city but not locations to put them in.  we need to drop this demand
     drop = need_more_jobs.index.difference(locations_series.unique())
     print "We don't have any locations for these locations:\n", drop
-    
-    print "TEMP INSTRUMENTING"
-    print type(need_more_jobs)
-    print type(drop)
-    print type(need_more_jobs.drop(drop))
-    print need_more_jobs
-    print drop
-    print need_more_jobs.drop(drop)
-    
     need_more_jobs = need_more_jobs.drop(drop).astype('int')
 
     # choose random locations within jurises to match need_more_jobs totals
@@ -520,10 +511,6 @@ def residential_developer(feasibility, households, buildings, parcels, year,
         # method below
         buildings = orca.get_table('buildings')
 
-        print "TEMP INSTRUMENTING"
-        print type(target)
-        print target
-
         new_buildings = utils.run_developer(
             "residential",
             households,
@@ -730,10 +717,6 @@ def office_developer(feasibility, jobs, buildings, parcels, year,
             # again because the buildings df gets modified by the run_developer
             # method below
             buildings = orca.get_table('buildings')
-
-            print "TEMP INSTRUMENTING"
-            print type(target)
-            print target
 
             new_buildings = utils.run_developer(
                 typ.lower(),

--- a/baus/utils.py
+++ b/baus/utils.py
@@ -207,13 +207,14 @@ def constrained_normalization(marginals, constraint, total):
 def simple_ipf(seed_matrix, col_marginals, row_marginals, tolerance=1, cnt=0):
     assert np.absolute(row_marginals.sum() - col_marginals.sum()) < 5.0
 
-    # certain numpy versions have trouble multiplying matrices by pd.Series; see PR #98
+    # most numpy/pandas combinations will perform this conversion
+    # automatically, but explicit is safer - see PR #98
     if isinstance(col_marginals, pd.Series):
         col_marginals = col_marginals.values
-    
+
     # first normalize on columns
     ratios = col_marginals / seed_matrix.sum(axis=0)
-    
+
     seed_matrix *= ratios
     closeness = np.absolute(row_marginals - seed_matrix.sum(axis=1)).sum()
     assert np.absolute(col_marginals - seed_matrix.sum(axis=0)).sum() < .01

--- a/baus/utils.py
+++ b/baus/utils.py
@@ -207,8 +207,13 @@ def constrained_normalization(marginals, constraint, total):
 def simple_ipf(seed_matrix, col_marginals, row_marginals, tolerance=1, cnt=0):
     assert np.absolute(row_marginals.sum() - col_marginals.sum()) < 5.0
 
+    # certain numpy versions have trouble multiplying matrices by pd.Series; see PR #98
+    if isinstance(col_marginals, pd.Series):
+        col_marginals = col_marginals.values
+    
     # first normalize on columns
     ratios = col_marginals / seed_matrix.sum(axis=0)
+    
     seed_matrix *= ratios
     closeness = np.absolute(row_marginals - seed_matrix.sum(axis=1)).sum()
     assert np.absolute(col_marginals - seed_matrix.sum(axis=0)).sum() < .01

--- a/baus/utils.py
+++ b/baus/utils.py
@@ -208,7 +208,7 @@ def simple_ipf(seed_matrix, col_marginals, row_marginals, tolerance=1, cnt=0):
     assert np.absolute(row_marginals.sum() - col_marginals.sum()) < 5.0
 
     # most numpy/pandas combinations will perform this conversion
-    # automatically, but explicit is safer - see PR #98
+    # automatically, but explicit is safer - see PR #99
     if isinstance(col_marginals, pd.Series):
         col_marginals = col_marginals.values
 


### PR DESCRIPTION
This PR fixes some bugs that were raising errors in the latest version of NumPy, v1.16. No changes to the model logic.

### Discussion

These problems and their fixes are discussed in more depth in Issue #96.

- In `utils.py`, a type check is added to the `constrained_normalization()` function. This converts `col_marginals` to a NumPy array if it's provided as a Pandas Series, ensuring that it can successfully be multiplied with a NumPy matrix later on. 

   This resolves an error that looks like this:
   `ValueError: Length of passed values is 1454, index implies 5`

- In `models.py`, the `_proportional_jobs_model()` function is modified to cast a series of job counts to integers. These values were consistently appearing as floats (in every sim iteration and multiple environments), but had been automatically converted in older versions of NumPy. 

   This resolves errors like this:
   `ValueError: No targets for given year: None`

- In `models.py`, the `residential_developer()` and `office_developer()` steps are modified to cast the unit count target to an integer before passing it to `urbansim_defaults`. Again, these targets were appearing as floats in every sim iteration and multiple environments, but had been automatically converted in older versions of NumPy. 

   This resolves errors like this:
   `TypeError: 'numpy.float64' object cannot be interpreted as an index`

### Testing

We tested these changes to make sure they don't affect the model output, using the random seed approach from PR #97. 

Environment 1:
- macOS, Python 2.7
- NumPy 1.10.4, UDST dependencies as in `requirements.txt`, everything else current

Environment 2:
- macOS, Python 2.7
- NumPy 1.16.4, UDST dependencies as in `requirements.txt`, everything else current

#### Confirming that the bug fixes work

We ran the default scenario to 2050 in both environments, with and without this PR. Without the PR, Environment 1 works but Environment 2 raises errors. After the PR, both environments work.

#### Confirming that the output doesn't change

We compared the `runXX_taz_summaries_2010.csv` output files from each of the runs. In Environment 1 (NumPy 1.10), the output is identical with and without this PR. In Environment 2 (NumPy 1.16), the values in the output remain the same but their format changes: values previously printed with 10 decimal places now have 16. This is from a change to NumPy's defaults.