### PR TITLE
Filter out parcels missing a location, to resolve Pandana error

### DIFF
--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -434,7 +434,8 @@ def zoning_scenario(parcels_geography, scenario, policy, mapping):
 
 @orca.table(cache=True)
 def parcels(store):
-    return store['parcels']
+    df = store['parcels']
+    return df.loc[df.x.notnull()]
 
 
 @orca.table(cache=True)


### PR DESCRIPTION
Four of the rows in the parcels table of `2015_09_01_bayarea_v3.h5` are missing lat-lon coordinates; rows reproduced [here](https://gist.github.com/smmaurer/9356ab43a089665a95fac37bccdf57b7).

This only recently became a problem, for reasons explained below, but the missing coordinates now raise an error the first time accessibilities are calculated. This PR adds a line of code in `datasources.py` to filter out the null parcels when the data file is loaded.

### What went wrong

Pandana matches parcels to travel network nodes based on lat-lon coordinates, using a function in scikit-learn. Before, scikit-learn would automatically filter out points that were missing coordinates. But new versions raise an error instead.

This had initially looked like a problem in Pandana, because it showed up with Pandana v0.4 but not v0.3 -- but actually it was due to differences in the associated scikit-learn installations. 