### PR TITLE
Minor install additions for windows

### DIFF
--- a/baus/models.py
+++ b/baus/models.py
@@ -338,7 +338,7 @@ def household_relocation(households, household_relocation_rates,
 
     # set households that are moving to a building_id of -1 (means unplaced)
     households.update_col_from_series("building_id",
-                                      pd.Series(-1, index=index).astype('int'))
+                                      pd.Series(-1, index=index), cast=True)
 
 
 # this deviates from the step in urbansim_defaults only in how it deals with

--- a/requirements-2019.txt
+++ b/requirements-2019.txt
@@ -10,3 +10,5 @@ orca_test == 0.1.*
 pandana == 0.3.*
 urbansim == 3.1.*
 urbansim_defaults == 0.2.*
+
+scikit-learn == 0.20.*

--- a/requirements-2019.txt
+++ b/requirements-2019.txt
@@ -12,3 +12,4 @@ urbansim == 3.1.*
 urbansim_defaults == 0.2.*
 
 scikit-learn == 0.20.*
+shapely == 1.6.*

--- a/requirements-2019.txt
+++ b/requirements-2019.txt
@@ -12,4 +12,4 @@ urbansim == 3.1.*
 urbansim_defaults == 0.2.*
 
 scikit-learn == 0.20.*
-shapely == 1.6.*
+pytables == 3.5.*


### PR DESCRIPTION
This PR adds a couple of items to @smmaurer's updates to the BAUS install process in [PR #117](https://github.com/BayAreaMetro/bayarea_urbansim/pull/117). These additions assure it works in Windows (Server 2012 R2). All packages added are cross-compatible with Python 2 and Python 3, following the original work. 

They include:

- adding an argument to `update_col_from_series`, that automatically casts data to the type being used by Pandas, which seems to differ by OS
- adding the scikit-learn dependency to the install process, which does not install automatically with Pandana on Windows
- upgrading the PyTables version to be compatible with the scikit-learn version