### PR TITLE
add xy to synthetic parcels

### DIFF
--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -435,7 +435,16 @@ def zoning_scenario(parcels_geography, scenario, policy, mapping):
 @orca.table(cache=True)
 def parcels(store):
     df = store['parcels']
-    return df.loc[df.x.notnull()]
+    # add a lat/lon to synthetic parcels to avoid a Pandana error
+    df.loc[2054503, "x"] = -122.1697
+    df.loc[2054503, "y"] = 37.4275
+    df.loc[2054504, "x"] = -122.1697
+    df.loc[2054504, "y"] = 37.4275
+    df.loc[2054505, "x"] = -122.1697
+    df.loc[2054505, "y"] = 37.4275
+    df.loc[2054506, "x"] = -122.1697
+    df.loc[2054506, "y"] = 37.4275
+    return df
 
 
 @orca.table(cache=True)


### PR DESCRIPTION
This builds on a previous PR [#124](https://github.com/BayAreaMetro/bayarea_urbansim/pull/124). In that PR, parcels with missing lat/lon were filtered out to resolve a Pandana issue. 

This created a problem in BAUS which had buildings allocated to those parcels. This PR adds those parcels back in, and assigns them lat/lon to avoid the Pandana issue-- the parcels don't have a true location, so this assigns the intended location near Stanford, specifically for use in Pandana accessibilities. Data will otherwise need to be cleaned up. 