### PR TITLE
Pba50 new input file geographic summaries - use new parcels_geography.csv with new pda IDs

### DIFF
--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -509,13 +509,12 @@ def parcels_geography(parcels, scenario, policy, settings):
 
     df['juris_trich'] = df.juris_id + df.trich_id
 
-    df["pda_id"] = df.pda_id.str.lower()
+    df["pda_id_pba40"] = df.pda_id_pba40.str.lower()
+    # danville wasn't supposed to be a pda
+    df["pda_id_pba40"] = df.pda_id_pba40.replace("dan1", np.nan)
 
-    if scenario not in policy["geographies_db_enable"]:
-        # danville wasn't supposed to be a pda
-        df["pda_id"] = df.pda_id.replace("dan1", np.nan)
-
-    # Add Draft Blueprint geographies: TRAs, PPA, sesit
+    # Add Draft Blueprint geographies: PDA, TRA, PPA, sesit
+    df["pad_id_pba50"] = df.pda_id_pba50.str.lower()
     df["tra_id"] = df.tra_id.str.lower()
     df['juris_tra'] = df.juris_id + df.tra_id
     df["ppa_id"] = df.ppa_id.str.lower()

--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -487,9 +487,9 @@ def parcel_rejections():
 
 
 @orca.table(cache=True)
-def parcels_geography(parcels, scenario, settings):
+def parcels_geography(parcels, scenario, policy, settings):
     df = pd.read_csv(
-        os.path.join(misc.data_dir(), "2020_04_17_parcels_geography.csv"),
+        os.path.join(misc.data_dir(), "2020_07_10_parcels_geography.csv"),
         index_col="geom_id")
     df = geom_id_to_parcel_id(df, parcels)
 
@@ -511,8 +511,17 @@ def parcels_geography(parcels, scenario, settings):
 
     df["pda_id"] = df.pda_id.str.lower()
 
-    # danville wasn't supposed to be a pda
-    df["pda_id"] = df.pda_id.replace("dan1", np.nan)
+    if scenario not in policy["geographies_db_enable"]:
+        # danville wasn't supposed to be a pda
+        df["pda_id"] = df.pda_id.replace("dan1", np.nan)
+
+    # Add Draft Blueprint geographies: TRAs, PPA, sesit
+    df["tra_id"] = df.tra_id.str.lower()
+    df['juris_tra'] = df.juris_id + df.tra_id
+    df["ppa_id"] = df.ppa_id.str.lower()
+    df['juris_ppa'] = df.juris_id + df.ppa_id
+    df["sesit_id"] = df.sesit_id.str.lower()
+    df['juris_sesit'] = df.juris_id + df.sesit_id
 
     return df
 

--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -487,7 +487,7 @@ def parcel_rejections():
 
 
 @orca.table(cache=True)
-def parcels_geography(parcels, scenario, policy, settings):
+def parcels_geography(parcels, scenario, settings):
     df = pd.read_csv(
         os.path.join(misc.data_dir(), "2020_07_10_parcels_geography.csv"),
         index_col="geom_id")

--- a/baus/models.py
+++ b/baus/models.py
@@ -434,11 +434,31 @@ def scheduled_development_events(buildings, development_projects,
     new_buildings["vmt_nonres_cat"] = misc.reindex(
         vmt_fee_categories.nonres_cat, new_buildings.zone_id)
     del new_buildings["zone_id"]
-    new_buildings["pda"] = parcels_geography.pda_id.loc[
+
+    # add PBA40 geographies
+    new_buildings["pda_pda40"] = parcels_geography.pda_id_pda40.loc[
         new_buildings.parcel_id].values
+
+    # add Horizon geographies
     new_buildings["juris_trich"] = parcels_geography.juris_trich.loc[
         new_buildings.parcel_id].values
 
+    # add Draft Blueprint geographies
+    new_buildings["pda_pda50"] = parcels_geography.pda_id_pda50.loc[
+        new_buildings.parcel_id].values
+    new_buildings["tra_id"] = parcels_geography.tra_id.loc[
+        new_buildings.parcel_id].values
+    new_buildings["ppa_id"] = parcels_geography.ppa_id.loc[
+        new_buildings.parcel_id].values
+    new_buildings["sesit_id"] = parcels_geography.sesit_id.loc[
+        new_buildings.parcel_id].values
+    new_buildings["juris_tra"] = parcels_geography.juris_tra.loc[
+        new_buildings.parcel_id].values
+    new_buildings["juris_ppa"] = parcels_geography.juris_ppa.loc[
+        new_buildings.parcel_id].values
+    new_buildings["juris_sesit"] = parcels_geography.juris_sesit.loc[
+        new_buildings.parcel_id].values
+    
     summary.add_parcel_output(new_buildings)
 
 

--- a/baus/models.py
+++ b/baus/models.py
@@ -458,7 +458,7 @@ def scheduled_development_events(buildings, development_projects,
         new_buildings.parcel_id].values
     new_buildings["juris_sesit"] = parcels_geography.juris_sesit.loc[
         new_buildings.parcel_id].values
-    
+
     summary.add_parcel_output(new_buildings)
 
 

--- a/baus/models.py
+++ b/baus/models.py
@@ -436,7 +436,7 @@ def scheduled_development_events(buildings, development_projects,
     del new_buildings["zone_id"]
 
     # add PBA40 geographies
-    new_buildings["pda_pda40"] = parcels_geography.pda_id_pda40.loc[
+    new_buildings["pda_pba40"] = parcels_geography.pda_id_pba40.loc[
         new_buildings.parcel_id].values
 
     # add Horizon geographies
@@ -444,7 +444,7 @@ def scheduled_development_events(buildings, development_projects,
         new_buildings.parcel_id].values
 
     # add Draft Blueprint geographies
-    new_buildings["pda_pda50"] = parcels_geography.pda_id_pda50.loc[
+    new_buildings["pda_pba50"] = parcels_geography.pda_id_pba50.loc[
         new_buildings.parcel_id].values
     new_buildings["tra_id"] = parcels_geography.tra_id.loc[
         new_buildings.parcel_id].values

--- a/baus/models.py
+++ b/baus/models.py
@@ -436,7 +436,7 @@ def scheduled_development_events(buildings, development_projects,
     del new_buildings["zone_id"]
 
     # add PBA40 geographies
-    new_buildings["pda_pba40"] = parcels_geography.pda_id_pba40.loc[
+    new_buildings["pda_pda40"] = parcels_geography.pda_id_pda40.loc[
         new_buildings.parcel_id].values
 
     # add Horizon geographies
@@ -444,7 +444,7 @@ def scheduled_development_events(buildings, development_projects,
         new_buildings.parcel_id].values
 
     # add Draft Blueprint geographies
-    new_buildings["pda_pba50"] = parcels_geography.pda_id_pba50.loc[
+    new_buildings["pda_pda50"] = parcels_geography.pda_id_pda50.loc[
         new_buildings.parcel_id].values
     new_buildings["tra_id"] = parcels_geography.tra_id.loc[
         new_buildings.parcel_id].values

--- a/baus/subsidies.py
+++ b/baus/subsidies.py
@@ -841,7 +841,7 @@ def run_subsidized_developer(feasibility, parcels, buildings, households,
 
 @orca.step()
 def subsidized_residential_feasibility(
-        parcels, settings, scenario, policy,
+        parcels, settings,
         add_extra_columns_func, parcel_sales_price_sqft_func,
         parcel_is_allowed_func, parcels_geography):
 

--- a/baus/subsidies.py
+++ b/baus/subsidies.py
@@ -843,7 +843,8 @@ def run_subsidized_developer(feasibility, parcels, buildings, households,
 def subsidized_residential_feasibility(
         parcels, settings,
         add_extra_columns_func, parcel_sales_price_sqft_func,
-        parcel_is_allowed_func, parcels_geography):
+        parcel_is_allowed_func, parcels_geography,
+        scenario, policy):
 
     kwargs = settings['feasibility'].copy()
     kwargs["only_built"] = False

--- a/baus/subsidies.py
+++ b/baus/subsidies.py
@@ -841,7 +841,7 @@ def run_subsidized_developer(feasibility, parcels, buildings, households,
 
 @orca.step()
 def subsidized_residential_feasibility(
-        parcels, settings,
+        parcels, settings, scenario, policy,
         add_extra_columns_func, parcel_sales_price_sqft_func,
         parcel_is_allowed_func, parcels_geography):
 

--- a/baus/subsidies.py
+++ b/baus/subsidies.py
@@ -843,8 +843,7 @@ def run_subsidized_developer(feasibility, parcels, buildings, households,
 def subsidized_residential_feasibility(
         parcels, settings,
         add_extra_columns_func, parcel_sales_price_sqft_func,
-        parcel_is_allowed_func, parcels_geography,
-        scenario, policy):
+        parcel_is_allowed_func, parcels_geography):
 
     kwargs = settings['feasibility'].copy()
     kwargs["only_built"] = False

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -429,7 +429,7 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
         hhincome_by_insesit = households_df.income.groupby(
             households_df.sesit_id.notnull()).mean()
         # round to nearest 100s
-        hhincome_by_insesit = (hhincome_by_insesit/100).round()*100    
+        hhincome_by_insesit = (hhincome_by_insesit/100).round()*100
 
     jobs_by_subregion = misc.reindex(taz_geography.subregion,
                                      jobs.zone_id).value_counts()
@@ -459,7 +459,7 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
 
     if year == 2010:
         # save some info for computing growth measures
-        if scenario in policy["geographies_pba40_enable"]:    
+        if scenario in policy["geographies_pba40_enable"]:
             orca.add_injectable("base_year_measures", {
                 "hh_by_subregion": hh_by_subregion,
                 "jobs_by_subregion": jobs_by_subregion,
@@ -583,7 +583,6 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
 
     write("Jobs pct of regional growth by subregion:\n%s" %
           norm_and_round(diff))
-
 
     # write PBA40 additional summaries: pda, tpp
     if scenario in policy["geographies_pba40_enable"]:
@@ -739,9 +738,9 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
     # for PBA40, compare pda jobs and households with ABAG targets
     if scenario in policy["geographies_pba40_enable"]:
         for geo, typ, corr in compare_to_targets(parcels, buildings, jobs,
-                                                households, abag_targets,
-                                                settings, scenario, policy,
-                                                write_comparison_dfs=True):
+                                                 households, abag_targets,
+                                                 settings,
+                                                 write_comparison_dfs=True):
             write("{} in {} have correlation of {:,.4f} with targets".format(
                 typ, geo, corr
             ))
@@ -750,8 +749,7 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
 
 
 def compare_to_targets(parcels, buildings, jobs, households, abag_targets,
-                       settings, scenario, policy,
-                       write_comparison_dfs=False):
+                       settings, write_comparison_dfs=False):
 
     # yes a similar join is used in the summarize step below - but it's
     # better to keep it clean and separate
@@ -771,21 +769,13 @@ def compare_to_targets(parcels, buildings, jobs, households, abag_targets,
         [parcels, buildings, jobs],
         columns=['pda_pba40', 'pda_pba50', 'juris'])
 
-    if scenario not in policy["geographies_db_enable"]:
-        households_df["pda_fill_juris"] = \
-            households_df.pda_pba40.str.upper().replace("Total", np.nan).\
-            str.upper().fillna(households_df.juris)
+    # only runs for pda_PBA40
+    households_df["pda_fill_juris"] = \
+        households_df.pda_pba40.str.upper().replace("Total", np.nan).\
+        str.upper().fillna(households_df.juris)
 
-        jobs_df["pda_fill_juris"] = \
-            jobs_df.pda_pba40.str.upper().fillna(jobs_df.juris)
-
-    if scenario in policy["geographies_db_enable"]:
-        households_df["pda_fill_juris"] = \
-            households_df.pda_pba50.str.upper().replace("Total", np.nan).\
-            str.upper().fillna(households_df.juris)
-
-        jobs_df["pda_fill_juris"] = \
-            jobs_df.pda_pba50.str.upper().fillna(jobs_df.juris)
+    jobs_df["pda_fill_juris"] = \
+        jobs_df.pda_pba40.str.upper().fillna(jobs_df.juris)
 
     # compute correlection for pda and juris, for households and for jobs
 
@@ -938,9 +928,10 @@ def geographic_summary(parcels, households, jobs, buildings, taz_geography,
     buildings_df = orca.merge_tables(
         'buildings',
         [parcels, buildings],
-        columns=['pda_pba40', 'pda_pba50', 'superdistrict', 'juris', 'building_type',
-                 'zone_id', 'residential_units', 'building_sqft',
-                 'non_residential_sqft', 'juris_trich', 'juris_tra', 'juris_sesit'])
+        columns=['pda_pba40', 'pda_pba50', 'superdistrict', 'juris',
+                 'building_type', 'zone_id', 'residential_units', 
+                 'building_sqft', 'non_residential_sqft', 
+                 'juris_trich', 'juris_tra', 'juris_sesit'])
 
     parcel_output = summary.parcel_output
 

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -553,10 +553,10 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
               base_year_measures["hhincome_by_intra"])
         write("Draft Blueprint year mean income by whether household\
               is in tra:\n%s" % hhincome_by_intra)
-        write("Base year mean income by whether household is in hra:\n%s" %
+        write("Base year mean income by whether household is in hra/dr:\n%s" %
               base_year_measures["hhincome_by_insesit"])
         write("Draft Blueprint year mean income by whether household\
-              is in hra:\n%s" % hhincome_by_insesit)
+              is in hra/dr:\n%s" % hhincome_by_insesit)
 
     jsp = buildings.job_spaces.sum()
     write("Number of job spaces = %d" % jsp)
@@ -702,14 +702,14 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
               norm_and_round(diff))
 
         tmp = base_year_measures["hh_by_insesit"]
-        write("Households base year share in hras:\n%s" %
+        write("Households base year share in hra/drs:\n%s" %
               norm_and_round(tmp))
 
-        write("Households share in hras:\n%s" %
+        write("Households share in hra/drs:\n%s" %
               norm_and_round(hh_by_insesit))
 
         diff = hh_by_insesit - base_year_measures["hh_by_insesit"]
-        write("Households pct of regional growth in hras:\n%s" %
+        write("Households pct of regional growth in hra/drs:\n%s" %
               norm_and_round(diff))
 
     write("Base year dwelling unit raw capacity:\n%s" %

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -929,8 +929,8 @@ def geographic_summary(parcels, households, jobs, buildings, taz_geography,
         'buildings',
         [parcels, buildings],
         columns=['pda_pba40', 'pda_pba50', 'superdistrict', 'juris',
-                 'building_type', 'zone_id', 'residential_units', 
-                 'building_sqft', 'non_residential_sqft', 
+                 'building_type', 'zone_id', 'residential_units',
+                 'building_sqft', 'non_residential_sqft',
                  'juris_trich', 'juris_tra', 'juris_sesit'])
 
     parcel_output = summary.parcel_output

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -395,7 +395,7 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
         hh_by_inpda_pba40 = households_df.pda_id_pba40.notnull().value_counts()
 
         hhincome_by_inpda_pba40 = households_df.income.groupby(
-            households_df.inpda_pba40.notnull()).mean()
+            households_df.pda_id_pba40.notnull()).mean()
         # round to nearest 100s
         hhincome_by_inpda_pba40 = (hhincome_by_inpda_pba40/100).round()*100
 
@@ -413,7 +413,7 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
         hh_by_inpda_pba50 = households_df.pda_id_pba50.notnull().value_counts()
 
         hhincome_by_inpda_pba50 = households_df.income.groupby(
-            households_df.inpda_pba50.notnull()).mean()
+            households_df.pda_id_pba50.notnull()).mean()
         # round to nearest 100s
         hhincome_by_inpda_pba50 = (hhincome_by_inpda_pba50/100).round()*100
 
@@ -437,7 +437,7 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
     jobs_df = orca.merge_tables(
         'jobs',
         [parcels, buildings, jobs],
-        columns=['pda_pba40', 'pda_pba50'])
+        columns=['pda_pba40', 'pda_pba50', 'trich_id', 'tra_id'])
 
     if settings["use_new_tpp_id_in_topsheet"]:
         jobs_df["tpp_id"] = misc.reindex(new_tpp_id.tpp_id,
@@ -447,8 +447,12 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
         jobs_by_inpda_pba40 = jobs_df.pda_pba40.notnull().value_counts()
         jobs_by_intpp = jobs_df.tpp_id.notnull().value_counts()
 
+    if scenario in policy["geographies_horizon_enable"]:
+        jobs_by_intrich = jobs_df.trich_id.notnull().value_counts()
+
     if scenario in policy["geographies_db_enable"]:
         jobs_by_inpda_pba50 = jobs_df.pda_pba50.notnull().value_counts()
+        jobs_by_intra = jobs_df.tra_id.notnull().value_counts()
 
     capacity = parcels_zoning_calculations.\
         zoned_du_underbuild_nodev.groupby(parcels.subregion).sum()
@@ -459,8 +463,8 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
             orca.add_injectable("base_year_measures", {
                 "hh_by_subregion": hh_by_subregion,
                 "jobs_by_subregion": jobs_by_subregion,
-                "hh_by_inpda_pba40": hh_by_inpda,
-                "jobs_by_inpda_pba40": jobs_by_inpda,
+                "hh_by_inpda_pba40": hh_by_inpda_pba40,
+                "jobs_by_inpda_pba40": jobs_by_inpda_pba40,
                 "hh_by_intpp": hh_by_intpp,
                 "jobs_by_intpp": jobs_by_intpp,
                 "hhincome_by_intpp": hhincome_by_intpp,
@@ -477,13 +481,12 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
             })
         if scenario in policy["geographies_db_enable"]:
             orca.add_injectable("base_year_measures", {
-            orca.add_injectable("base_year_measures", {
                 "hh_by_subregion": hh_by_subregion,
                 "jobs_by_subregion": jobs_by_subregion,
-                "hh_by_inpda_pba50": hh_by_inpda_db,
+                "hh_by_inpda_pba50": hh_by_inpda_pba50,
                 "hh_by_intra": hh_by_intra,
                 "hh_by_insesit": hh_by_insesit,
-                "jobs_by_inpda_pba50": jobs_by_inpda_db,
+                "jobs_by_inpda_pba50": jobs_by_inpda_pba50,
                 "jobs_by_intra": jobs_by_intra,
                 "hhincome_by_intra": hhincome_by_intra,
                 "hhincome_by_insesit": hhincome_by_insesit,

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -736,13 +736,15 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
     jobs_by_housing = jobs_by_county / households_by_county.replace(0, 1)
     write("Jobs/housing balance:\n" + str(jobs_by_housing))
 
-    for geo, typ, corr in compare_to_targets(parcels, buildings, jobs,
-                                             households, abag_targets,
-                                             settings, scenario, policy,
-                                             write_comparison_dfs=True):
-        write("{} in {} have correlation of {:,.4f} with targets".format(
-            typ, geo, corr
-        ))
+    # for PBA40, compare pda jobs and households with ABAG targets
+    if scenario in policy["geographies_pba40_enable"]:
+        for geo, typ, corr in compare_to_targets(parcels, buildings, jobs,
+                                                households, abag_targets,
+                                                settings, scenario, policy,
+                                                write_comparison_dfs=True):
+            write("{} in {} have correlation of {:,.4f} with targets".format(
+                typ, geo, corr
+            ))
 
     f.close()
 

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -400,7 +400,7 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
         hhincome_by_inpda_pba40 = (hhincome_by_inpda_pba40/100).round()*100
 
     # Summaries for Horizon geographies
-    if scenario in policy["geographies_horizon_enable"]:
+    if scenario in policy["geographies_fr2_enable"]:
         hh_by_intrich = households_df.trich_id.notnull().value_counts()
 
         hhincome_by_intrich = households_df.income.groupby(
@@ -447,7 +447,7 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
         jobs_by_inpda_pba40 = jobs_df.pda_pba40.notnull().value_counts()
         jobs_by_intpp = jobs_df.tpp_id.notnull().value_counts()
 
-    if scenario in policy["geographies_horizon_enable"]:
+    if scenario in policy["geographies_fr2_enable"]:
         jobs_by_intrich = jobs_df.trich_id.notnull().value_counts()
 
     if scenario in policy["geographies_db_enable"]:
@@ -470,7 +470,7 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
                 "hhincome_by_intpp": hhincome_by_intpp,
                 "capacity": capacity
             })
-        if scenario in policy["geographies_horizon_enable"]:
+        if scenario in policy["geographies_fr2_enable"]:
             orca.add_injectable("base_year_measures", {
                 "hh_by_subregion": hh_by_subregion,
                 "jobs_by_subregion": jobs_by_subregion,
@@ -632,7 +632,7 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
               norm_and_round(diff))
 
     # write Horizon additional summaries: trich
-    if scenario in policy["geographies_horizon_enable"]:
+    if scenario in policy["geographies_fr2_enable"]:
         tmp = base_year_measures["hh_by_intrich"]
         write("Households base year share in trichs:\n%s" %
               norm_and_round(tmp))

--- a/baus/variables.py
+++ b/baus/variables.py
@@ -330,8 +330,9 @@ def maz_id(parcels, parcel_to_maz):
 
 
 @orca.column("parcels")
-def residential_sales_price_sqft(parcel_sales_price_sqft_func):
-    return parcel_sales_price_sqft_func("residential")
+def residential_sales_price_sqft(parcel_sales_price_sqft_func,
+                                 scenario, policy):
+    return parcel_sales_price_sqft_func("residential", scenario, policy)
 
 
 @orca.column('parcels')
@@ -523,17 +524,18 @@ def ave_sqft_per_unit(parcels, zones, settings):
 # these are actually functions that take parameters,
 # but are parcel-related so are defined here
 @orca.injectable("parcel_sales_price_sqft_func", autocall=False)
-def parcel_average_price(use, quantile=.5):
+def parcel_average_price(use, scenario, policy, quantile=.5):
     if use == "residential":
         # get node price average and put it on parcels
         s = misc.reindex(orca.get_table('nodes')[use],
                          orca.get_table('parcels').node_id)
 
-        # apply shifters
-        cost_shifters = orca.get_table("parcels").cost_shifters
-        price_shifters = orca.get_table("parcels").price_shifters
-        taz2_shifters = orca.get_table("parcels").taz2_price_shifters
-        s = s / cost_shifters * price_shifters * taz2_shifters
+        # apply shifters for PBA40
+        if scenario in policy["geographies_pba40_enable"]:
+            cost_shifters = orca.get_table("parcels").cost_shifters
+            price_shifters = orca.get_table("parcels").price_shifters
+            taz2_shifters = orca.get_table("parcels").taz2_price_shifters
+            s = s / cost_shifters * price_shifters * taz2_shifters
 
         # just to make sure we're in a reasonable range
         return s.fillna(0).clip(150, 1250)
@@ -758,7 +760,7 @@ def general_type(parcels, buildings):
 
 # for debugging reasons this is split out into its own function
 @orca.column('parcels')
-def building_purchase_price_sqft(parcels, settings):
+def building_purchase_price_sqft(parcels, settings, scenario, policy):
     price = pd.Series(0, parcels.index)
     gentype = parcels.general_type
     cap_rate = settings["cap_rate"]
@@ -775,7 +777,7 @@ def building_purchase_price_sqft(parcels, settings):
             factor *= 2.0
         if form == "Office":
             factor *= 1.4
-        tmp = parcel_average_price(form.lower())
+        tmp = parcel_average_price(form.lower(), scenario, policy)
         price += tmp * (gentype == form) * factor
 
     # this is not a very constraining clip

--- a/baus/variables.py
+++ b/baus/variables.py
@@ -409,8 +409,13 @@ def fees_per_sqft(parcels, policy, scenario):
 
 
 @orca.column('parcels', cache=True)
-def pda(parcels, parcels_geography):
-    return parcels_geography.pda_id.reindex(parcels.index)
+def pda_pba40(parcels, parcels_geography):
+    return parcels_geography.pda_id_pba40.reindex(parcels.index)
+
+
+@orca.column('parcels', cache=True)
+def pda_pba50(parcels, parcels_geography):
+    return parcels_geography.pda_id_pba50.reindex(parcels.index)
 
 
 @orca.column('parcels', cache=True)
@@ -426,6 +431,36 @@ def cat_id(parcels, parcels_geography):
 @orca.column('parcels', cache=True)
 def juris_trich(parcels, parcels_geography):
     return parcels_geography.juris_trich.reindex(parcels.index)
+
+
+@orca.column('parcels', cache=True)
+def tra_id(parcels, parcels_geography):
+    return parcels_geography.tra_id.reindex(parcels.index)
+
+
+@orca.column('parcels', cache=True)
+def juris_tra(parcels, parcels_geography):
+    return parcels_geography.juris_tra.reindex(parcels.index)
+
+
+@orca.column('parcels', cache=True)
+def sesit_id(parcels, parcels_geography):
+    return parcels_geography.sesit_id.reindex(parcels.index)
+
+
+@orca.column('parcels', cache=True)
+def juris_sesit(parcels, parcels_geography):
+    return parcels_geography.juris_sesit.reindex(parcels.index)
+
+
+@orca.column('parcels', cache=True)
+def ppa_id(parcels, parcels_geography):
+    return parcels_geography.ppa_id.reindex(parcels.index)
+
+
+@orca.column('parcels', cache=True)
+def juris_ppa(parcels, parcels_geography):
+    return parcels_geography.juris_ppa.reindex(parcels.index)
 
 
 @orca.column('parcels', cache=True)

--- a/baus/variables.py
+++ b/baus/variables.py
@@ -330,9 +330,8 @@ def maz_id(parcels, parcel_to_maz):
 
 
 @orca.column("parcels")
-def residential_sales_price_sqft(parcel_sales_price_sqft_func,
-                                 scenario, policy):
-    return parcel_sales_price_sqft_func("residential", scenario, policy)
+def residential_sales_price_sqft(parcel_sales_price_sqft_func):
+    return parcel_sales_price_sqft_func("residential")
 
 
 @orca.column('parcels')
@@ -524,7 +523,7 @@ def ave_sqft_per_unit(parcels, zones, settings):
 # these are actually functions that take parameters,
 # but are parcel-related so are defined here
 @orca.injectable("parcel_sales_price_sqft_func", autocall=False)
-def parcel_average_price(use, scenario, policy, quantile=.5):
+def parcel_average_price(use, quantile=.5):
     if use == "residential":
         # get node price average and put it on parcels
         s = misc.reindex(orca.get_table('nodes')[use],
@@ -532,12 +531,7 @@ def parcel_average_price(use, scenario, policy, quantile=.5):
 
         # apply shifters
         cost_shifters = orca.get_table("parcels").cost_shifters
-
-        if scenario in policy["geographies_db_enable"]:
-            price_shifters = orca.get_table("parcels").price_shifters_pba50
-        else:
-            price_shifters = orca.get_table("parcels").price_shifters_pba40
-
+        price_shifters = orca.get_table("parcels").price_shifters
         taz2_shifters = orca.get_table("parcels").taz2_price_shifters
         s = s / cost_shifters * price_shifters * taz2_shifters
 
@@ -764,7 +758,7 @@ def general_type(parcels, buildings):
 
 # for debugging reasons this is split out into its own function
 @orca.column('parcels')
-def building_purchase_price_sqft(parcels, settings, scenario, policy):
+def building_purchase_price_sqft(parcels, settings):
     price = pd.Series(0, parcels.index)
     gentype = parcels.general_type
     cap_rate = settings["cap_rate"]
@@ -781,7 +775,7 @@ def building_purchase_price_sqft(parcels, settings, scenario, policy):
             factor *= 2.0
         if form == "Office":
             factor *= 1.4
-        tmp = parcel_average_price(form.lower(), scenario, policy)
+        tmp = parcel_average_price(form.lower())
         price += tmp * (gentype == form) * factor
 
     # this is not a very constraining clip
@@ -825,13 +819,8 @@ def cost_shifters(parcels, settings):
 
 
 @orca.column('parcels', cache=True)
-def price_shifters_pba40(parcels, settings):
-    return parcels.pda_pba40.map(settings["pda_price_shifters"]).fillna(1.0)
-
-
-@orca.column('parcels', cache=True)
-def price_shifters_pba50(parcels, settings):
-    return parcels.pda_pba50.map(settings["pda_price_shifters"]).fillna(1.0)
+def price_shifters(parcels, settings):
+    return parcels.pda.map(settings["pda_price_shifters"]).fillna(1.0)
 
 
 @orca.column('parcels', cache=True)

--- a/baus/variables.py
+++ b/baus/variables.py
@@ -819,8 +819,12 @@ def cost_shifters(parcels, settings):
 
 
 @orca.column('parcels', cache=True)
-def price_shifters(parcels, settings):
-    return parcels.pda.map(settings["pda_price_shifters"]).fillna(1.0)
+def price_shifters(parcels, settings, scenario, policy):
+    if scenario in policy["geographies_pba40_enable"] or \
+            scenario in policy["geographies_horizon_enable"] :
+        return parcels.pda_pba40.map(settings["pda_price_shifters"]).fillna(1.0)
+    elif scenario in policy["geographies_db_enable"]:
+        return parcels.pda_pba50.map(settings["pda_price_shifters"]).fillna(1.0)
 
 
 @orca.column('parcels', cache=True)

--- a/baus/variables.py
+++ b/baus/variables.py
@@ -820,8 +820,7 @@ def cost_shifters(parcels, settings):
 
 @orca.column('parcels', cache=True)
 def price_shifters(parcels, settings, scenario, policy):
-    if scenario in policy["geographies_pba40_enable"] or \
-            scenario in policy["geographies_horizon_enable"] :
+    if scenario not in policy["geographies_db_enable"] :
         return parcels.pda_pba40.map(settings["pda_price_shifters"]).fillna(1.0)
     elif scenario in policy["geographies_db_enable"]:
         return parcels.pda_pba50.map(settings["pda_price_shifters"]).fillna(1.0)

--- a/baus/variables.py
+++ b/baus/variables.py
@@ -532,7 +532,7 @@ def parcel_average_price(use, quantile=.5):
         cost_shifters = orca.get_table("parcels").cost_shifters
         price_shifters = orca.get_table("parcels").price_shifters
         taz2_shifters = orca.get_table("parcels").taz2_price_shifters
-     
+
         s = s / cost_shifters * price_shifters * taz2_shifters
 
         # just to make sure we're in a reasonable range
@@ -820,8 +820,9 @@ def cost_shifters(parcels, settings):
 
 @orca.column('parcels', cache=True)
 def price_shifters(parcels, settings, scenario, policy):
-    if scenario not in policy["geographies_db_enable"] :
-        return parcels.pda_pba40.map(settings["pda_price_shifters"]).fillna(1.0)
+    if scenario not in policy["geographies_db_enable"]:
+        return parcels.pda_pba40.map(
+                    settings["pda_price_shifters"]).fillna(1.0)
     elif scenario in policy["geographies_db_enable"]:
         return pd.Series(1.0, parcels.index)
 

--- a/configs/policy.yaml
+++ b/configs/policy.yaml
@@ -8,6 +8,15 @@
 # catalyst sites are upzoned
 geographies_fr2_enable: ["11", "12", "15"]
 
+# scenarios for PBA40
+geographies_pba40_enable: ["0", "3", "4"]
+
+# scenarios for Horizon
+geographies_horizon_enable: ["1", "2", "5", "6", "7", "10", "11", "12", "15"]
+
+# scenarios for Draft Blueprint geographis - PDA, TRA, SESIT (HRA, DR)
+geographies_db_enable: ["20", "21", "22", "23"]
+
 # scenarios for futures round 2 office caps
 office_caps_fr2_enable: ["11", "12", "15"]
 

--- a/configs/policy.yaml
+++ b/configs/policy.yaml
@@ -11,9 +11,6 @@ geographies_fr2_enable: ["11", "12", "15"]
 # scenarios for PBA40
 geographies_pba40_enable: ["0", "3", "4"]
 
-# scenarios for Horizon
-geographies_horizon_enable: ["1", "2", "5", "6", "7", "10", "11", "12", "15"]
-
 # scenarios for Draft Blueprint geographis - PDA, TRA, SESIT (HRA, DR)
 geographies_db_enable: ["20", "21", "22", "23"]
 

--- a/configs/settings.yaml
+++ b/configs/settings.yaml
@@ -91,9 +91,13 @@ feasibility:
     - building_purchase_price
     - building_purchase_price_sqft
     - residential_sales_price_sqft
-    - pda
+    - pda_pba40
+    - pda_pba50
     - trich_id
     - cat_id
+    - tra_id
+    - ppa_id
+    - sesit_id
     - juris
     - county
     - superdistrict
@@ -196,7 +200,8 @@ rent_equilibration:
 
 # SHIFTERS
 
-# price shisfters per pda - price is multiplied by this amount
+# only for PBA40
+# price shifters per pda - price is multiplied by this amount
 pda_price_shifters:
   "ber1": 1
   "ber2": 1


### PR DESCRIPTION
This is another (and cleaner) approach of creating plan-specific geographic summaries. I modified `parcels_geography.csv` to add a new `pda_pba50` field and rename the previous pda field as `pda_pba40`. This way, we can avoid using `use_new_pda_id_in_topsheet` and a separate `pda_id.csv` input file to add an rename fields when creating summaries. 

This branch is also based on run-staging. I'll run both this branch and the previous "Add pba50 geographies summary - started from 'run-staging'" branch to compare the results.