### PR TITLE
Add juris resunits

### DIFF
--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -995,6 +995,8 @@ def geographic_summary(parcels, households, jobs, buildings, taz_geography,
                 groupby(geography).size()
 
             # residential buildings by type
+            summary_table['res_units'] = buildings_df.groupby(geography).\
+                residential_units.sum()
             summary_table['sfdu'] = buildings_df.\
                 query("building_type == 'HS' or building_type == 'HT'").\
                 groupby(geography).residential_units.sum()


### PR DESCRIPTION
This PR adds a residential units column to the superdistrict and jurisdiction summaries, so we see how many total res units were built, rather than only SFDU and MFDU which don't capture them all. 

To test the changes I ran the model through the full simulation, which completed with no errors (given the tests we currently have). To test the new feature I checked that new  residential units column appeared in the SD and juris summaries, and that these geographies always had more total residential units than total households. 