### PR TITLE
Use full jurisdiction name

### DIFF
--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -507,7 +507,7 @@ def parcels_geography(parcels, scenario, settings):
     # assert no empty juris values
     assert True not in df.juris_name.isnull().value_counts()
 
-    df['juris_trich'] = df.juris_id + df.trich_id
+    df['juris_trich'] = df.juris + '-' + df.trich_id
 
     df["pda_id_pba40"] = df.pda_id_pba40.str.lower()
     # danville wasn't supposed to be a pda
@@ -516,11 +516,11 @@ def parcels_geography(parcels, scenario, settings):
     # Add Draft Blueprint geographies: PDA, TRA, PPA, sesit
     df["pad_id_pba50"] = df.pda_id_pba50.str.lower()
     df["tra_id"] = df.tra_id.str.lower()
-    df['juris_tra'] = df.juris_id + df.tra_id
+    df['juris_tra'] = df.juris + '-' + df.tra_id
     df["ppa_id"] = df.ppa_id.str.lower()
-    df['juris_ppa'] = df.juris_id + df.ppa_id
+    df['juris_ppa'] = df.juris + '-' + df.ppa_id
     df["sesit_id"] = df.sesit_id.str.lower()
-    df['juris_sesit'] = df.juris_id + df.sesit_id
+    df['juris_sesit'] = df.juris + '-' + df.sesit_id
 
     return df
 

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -922,7 +922,8 @@ def geographic_summary(parcels, households, jobs, buildings, taz_geography,
         'jobs',
         [parcels, buildings, jobs],
         columns=['pda_pba40', 'pda_pba50', 'superdistrict', 'juris', 'zone_id',
-                 'empsix', 'juris_trich', 'juris_tra', 'juris_sesit', 'juris_ppa'])
+                 'empsix', 'juris_trich', 'juris_tra',
+                 'juris_sesit', 'juris_ppa'])
 
     buildings_df = orca.merge_tables(
         'buildings',


### PR DESCRIPTION
Replace the 4-letter abbreviation of jurisdiction names with the full name. The full name was added to "parcels_geography.csv".