### PR TITLE
add a source column to the buildings table

### DIFF
--- a/baus/models.py
+++ b/baus/models.py
@@ -497,6 +497,8 @@ def form_to_btype_func(building):
 
 @orca.injectable(autocall=False)
 def add_extra_columns_func(df):
+    df['source'] = 'developer_model'
+
     for col in ["residential_price", "non_residential_rent"]:
         df[col] = 0
 

--- a/baus/preprocessing.py
+++ b/baus/preprocessing.py
@@ -284,6 +284,9 @@ def preproc_buildings(store, parcels, manual_edits):
     # start with buildings from urbansim_defaults
     df = store['buildings']
 
+    # add source of buildings data (vs pipeline, developer model)
+    df['source'] = 'h5_inputs'
+
     # this is code from urbansim_defaults
     df["residential_units"] = pd.concat(
         [df.residential_units,

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -1161,7 +1161,8 @@ def building_summary(parcels, run_number, year,
         [parcels, buildings],
         columns=['performance_zone', 'year_built', 'residential_units',
                  'unit_price', 'zone_id', 'non_residential_sqft',
-                 'deed_restricted_units', 'job_spaces', 'x', 'y', 'geom_id'])
+                 'deed_restricted_units', 'job_spaces', 'x', 'y', 'geom_id', 
+                 'source'])
 
     df.to_csv(
         os.path.join("runs", "run%d_building_data_%d.csv" %

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -1161,7 +1161,7 @@ def building_summary(parcels, run_number, year,
         [parcels, buildings],
         columns=['performance_zone', 'year_built', 'residential_units',
                  'unit_price', 'zone_id', 'non_residential_sqft',
-                 'deed_restricted_units', 'job_spaces', 'x', 'y', 'geom_id', 
+                 'deed_restricted_units', 'job_spaces', 'x', 'y', 'geom_id',
                  'source'])
 
     df.to_csv(


### PR DESCRIPTION
This PR adds a `source` column to the buildings table to distinguish buildings by: h5 buildings, pipieline buildings, and developer buildings. These show up in the buildings output to help determine where growth came from. Fletcher will be adding a field to the visualizer so that we can see this there as well. 

I ran the model to 2050 and checked that the buildings table had the correct tags as well as `parcel_output.csv` which is used by the visualizer. 