### PR TITLE
Enable models so that Q1 can occupy deed restricted units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ venv
 ual_baus_install.sh
 configs/hlcm_renter_no_unplaced.yaml
 configs/hlcm_owner_no_unplaced.yaml
+configs/hlcm_renter_lowincome_no_unplaced.yaml
+configs/hlcm_owner_lowincome_no_unplaced.yaml
 data/2015_06_01_zoning_parcels.csv
 data/2015_08_13_parcels_geography.csv
 data/2015_08_13_zoning_parcels.csv

--- a/baus.py
+++ b/baus.py
@@ -340,9 +340,7 @@ def run_models(MODE, SCENARIO):
                 # we have to run the hlcm above before this one - we first want 
                 # to try and put unplaced households into their appropraite 
                 # tenured units and then when that fails, force them to place 
-                # using the code below.  technically the hlcms above could be 
-                # moved above the developer again, but we would have to run the 
-                # hedonics twice and also the assign_tenure_to_new_units twice.
+                # using the code below. 
 
                 # force placement of any unplaced households, in terms of 
                 # rent/own, is a noop except in the final simulation year

--- a/baus.py
+++ b/baus.py
@@ -192,6 +192,11 @@ def get_simulation_models(SCENARIO):
         # allocate renters to vacant rental units
         "hlcm_renter_simulate",
 
+        # we first put Q1/Q2/Q3 in market-rate units, then allow
+        # Q1 into deed-restricted and market-rate units
+        "hlcm_owner_lowincome_simulate",
+        "hlcm_renter_lowincome_simulate",
+
         # we have to run the hlcm above before this one - we first want to
         # try and put unplaced households into their appropraite tenured
         # units and then when that fails, force them to place using the
@@ -310,6 +315,10 @@ def run_models(MODE, SCENARIO):
                 "hlcm_owner_simulate",
                 # allocate renters to vacant rental units
                 "hlcm_renter_simulate",
+                # we first put Q1/Q2/Q3 in market-rate units, then allow
+                # Q1 into deed-restricted and market-rate units
+                "hlcm_owner_lowincome_simulate",
+                "hlcm_renter_lowincome_simulate",
                 # update building/unit/hh correspondence
                 "reconcile_placed_households",
 

--- a/baus.py
+++ b/baus.py
@@ -327,8 +327,8 @@ def run_models(MODE, SCENARIO):
                 # allocate renters to vacant rental units
                 "hlcm_renter_simulate",
 
-                # we first put Q1/Q2/Q3 in market-rate units only, then allow 
-                # Q1 into either deed-restricted or market-rate units
+                # we first put Q1/Q2/Q3 in market-rate units only, then  
+                # allow Q1 into either deed-restricted or market-rate units
                 # this leaves deed-restricted units and the remaining 
                 # market-rate units for Q1, whereas placing Q1 first could 
                 # leave deed-restricted units vacant-- since deed-restricted 

--- a/baus.py
+++ b/baus.py
@@ -194,8 +194,12 @@ def get_simulation_models(SCENARIO):
         # allocate renters to vacant rental units
         "hlcm_renter_simulate",
 
-        # we first put Q1/Q2/Q3 in market-rate units, then allow
-        # Q1 into deed-restricted and market-rate units
+        # we first put Q1/Q2/Q3 in market-rate units only, then allow Q1 into 
+        # either deed-restricted or market-rate units
+        # this leaves deed-restricted units and the remaining market-rate
+        # units for Q1, whereas placing Q1 first could leave deed-restricted
+        # units vacant-- since deed-restricted units are not explicitly
+        # tied to price, there is not a greater probability Q1 will choose them
         "hlcm_owner_lowincome_simulate",
         "hlcm_renter_lowincome_simulate",
 
@@ -208,10 +212,14 @@ def get_simulation_models(SCENARIO):
 
         # force placement of any unplaced households, in terms of rent/own
         # is a noop except in the final simulation year
+        # 09 11 2020 ET: enabled for all simulation years
         "hlcm_owner_simulate_no_unplaced",
+        "hlcm_owner_lowincome_simulate_no_unplaced",
         # this one crashes right no because there are no unplaced, so
         # need to fix the crash in urbansim
+        # 09 11 2020 ET: appears to be working
         "hlcm_renter_simulate_no_unplaced",
+        "hlcm_renter_lowincome_simulate_no_unplaced",
 
         # update building/unit/hh correspondence
         "reconcile_placed_households",
@@ -318,10 +326,35 @@ def run_models(MODE, SCENARIO):
                 "hlcm_owner_simulate",
                 # allocate renters to vacant rental units
                 "hlcm_renter_simulate",
-                # we first put Q1/Q2/Q3 in market-rate units, then allow
-                # Q1 into deed-restricted and market-rate units
+
+                # we first put Q1/Q2/Q3 in market-rate units only, then allow 
+                # Q1 into either deed-restricted or market-rate units
+                # this leaves deed-restricted units and the remaining 
+                # market-rate units for Q1, whereas placing Q1 first could 
+                # leave deed-restricted units vacant-- since deed-restricted 
+                # units are not explicitly tied to price, there is not a 
+                # greater probability Q1 will choose them
                 "hlcm_owner_lowincome_simulate",
                 "hlcm_renter_lowincome_simulate",
+
+                # we have to run the hlcm above before this one - we first want 
+                # to try and put unplaced households into their appropraite 
+                # tenured units and then when that fails, force them to place 
+                # using the code below.  technically the hlcms above could be 
+                # moved above the developer again, but we would have to run the 
+                # hedonics twice and also the assign_tenure_to_new_units twice.
+
+                # force placement of any unplaced households, in terms of 
+                # rent/own, is a noop except in the final simulation year
+                # 09 11 2020 ET: enabled for all simulation years
+                "hlcm_owner_simulate_no_unplaced",
+                "hlcm_owner_lowincome_simulate_no_unplaced",
+                # this one crashes right no because there are no unplaced, so
+                # need to fix the crash in urbansim
+                # 09 11 2020 ET: appears to be working
+                "hlcm_renter_simulate_no_unplaced",
+                "hlcm_renter_lowincome_simulate_no_unplaced",
+
                 # update building/unit/hh correspondence
                 "reconcile_placed_households",
 

--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -181,6 +181,10 @@ def hlcm_owner_no_unplaced_config():
 def hlcm_owner_lowincome_config():
     return get_config_file('hlcm_owner_lowincome')
 
+@orca.injectable(cache=True)
+def hlcm_owner_lowincome_no_unplaced_config():
+    return get_config_file('hlcm_owner_lowincome_no_unplaced')
+
 
 @orca.injectable(cache=True)
 def hlcm_renter_config():
@@ -195,6 +199,11 @@ def hlcm_renter_no_unplaced_config():
 @orca.injectable(cache=True)
 def hlcm_renter_lowincome_config():
     return get_config_file('hlcm_renter_lowincome')
+
+
+@orca.injectable(cache=True)
+def hlcm_renter_lowincome_no_unplaced_config():
+    return get_config_file('hlcm_renter_lowincome_no_unplaced')
 
 
 @orca.injectable(cache=True)

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -1169,9 +1169,9 @@ def building_summary(parcels, run_number, year,
         'buildings',
         [parcels, buildings],
         columns=['performance_zone', 'year_built', 'residential_units',
-                 'unit_price', 'zone_id', 'non_residential_sqft',
-                 'deed_restricted_units', 'job_spaces', 'x', 'y', 'geom_id',
-                 'source'])
+                 'unit_price', 'zone_id', 'non_residential_sqft', 
+                 'vacant_res_units', 'deed_restricted_units', 'job_spaces', 
+                 'x', 'y', 'geom_id', 'source'])
 
     df.to_csv(
         os.path.join("runs", "run%d_building_data_%d.csv" %

--- a/baus/ual.py
+++ b/baus/ual.py
@@ -838,9 +838,15 @@ def hlcm_owner_lowincome_simulate(households, residential_units,
                                   aggregations, settings,
                                   hlcm_owner_lowincome_config):
 
-    return hlcm_simulate(households, residential_units, aggregations,
-                         settings, hlcm_owner_lowincome_config,
-                         'price_equilibration')
+
+    # Pre-filter the alternatives to avoid over-pruning (PR 103)
+    correct_alternative_filters_sample(residential_units, households, 'own')
+
+    hlcm_simulate(orca.get_table('own_hh'), orca.get_table('own_units'),
+                  aggregations, settings, hlcm_owner_lowincome_config,
+                  'price_equilibration')
+
+    update_unit_ids(households, 'own')
 
 
 @orca.step()
@@ -852,6 +858,20 @@ def hlcm_renter_simulate(households, residential_units, aggregations,
 
     hlcm_simulate(orca.get_table('rent_hh'), orca.get_table('rent_units'),
                   aggregations, settings, hlcm_renter_config,
+                  'rent_equilibration')
+
+    update_unit_ids(households, 'rent')
+
+
+@orca.step()
+def hlcm_renter_lowincome_simulate(households, residential_units, aggregations,
+                                   settings, hlcm_renter_lowincome_config):
+
+    # Pre-filter the alternatives to avoid over-pruning (PR 103)
+    correct_alternative_filters_sample(residential_units, households, 'rent')
+
+    hlcm_simulate(orca.get_table('rent_hh'), orca.get_table('rent_units'),
+                  aggregations, settings, hlcm_renter_lowincome_config,
                   'rent_equilibration')
 
     update_unit_ids(households, 'rent')
@@ -914,14 +934,6 @@ def update_unit_ids(households, tenure):
     unit_ids.loc[unit_ids.index.isin(updated.index),
                  'unit_id'] = updated['unit_id']
     households.update_col_from_series('unit_id', unit_ids.unit_id, cast=True)
-
-
-@orca.step()
-def hlcm_renter_lowincome_simulate(households, residential_units, aggregations,
-                                   settings, hlcm_renter_lowincome_config):
-    return hlcm_simulate(households, residential_units, aggregations,
-                         settings, hlcm_renter_lowincome_config,
-                         'rent_equilibration')
 
 
 # this opens the yaml file, deletes the predict filters and writes it to the

--- a/baus/ual.py
+++ b/baus/ual.py
@@ -926,16 +926,21 @@ def hlcm_renter_lowincome_simulate(households, residential_units, aggregations,
 
 # this opens the yaml file, deletes the predict filters and writes it to the
 # out name - since the alts don't have a filter, all hhlds should be placed
-def drop_predict_filters_from_yaml(in_yaml_name, out_yaml_name):
+def drop_tenure_predict_filters_from_yaml(in_yaml_name, out_yaml_name):
     fname = misc.config(in_yaml_name)
     cfg = yaml.load(open(fname))
     cfg["alts_predict_filters"] = None
+    if 'lowincome' not in in_yaml_name:
+        cfg["alts_predict_filters"] = 'deed_restricted == False'
     open(misc.config(out_yaml_name), "w").write(yaml.dump(cfg))
 
 
 # see comment above - these hlcms ignore tenure in the alternatives and so
 # place households as long as there are empty units - this should only run
 # in the final year
+# 09 08 2020 ET: we'll run these every year for now, because
+# allowing only Q1 into deed-restricted units exacerbates the tenure
+# units-households alignment issue
 @orca.step()
 def hlcm_owner_simulate_no_unplaced(households, residential_units,
                                     year, final_year,
@@ -944,15 +949,35 @@ def hlcm_owner_simulate_no_unplaced(households, residential_units,
                                     hlcm_owner_no_unplaced_config):
 
     # only run in the last year, but make sure to run before summaries
-    if year != final_year:
-        return
+#    if year != final_year:
+#        return
 
-    drop_predict_filters_from_yaml(
+    drop_tenure_predict_filters_from_yaml(
         hlcm_owner_config,
         hlcm_owner_no_unplaced_config)
 
     return hlcm_simulate(households, residential_units, aggregations,
                          settings, hlcm_owner_no_unplaced_config,
+                         "price_equilibration")
+
+
+@orca.step()
+def hlcm_owner_lowincome_simulate_no_unplaced(households, residential_units,
+                                              year, final_year,
+                                              aggregations, settings,
+                                              hlcm_owner_lowincome_config,
+                                              hlcm_owner_lowincome_no_unplaced_config):
+
+    # only run in the last year, but make sure to run before summaries
+#    if year != final_year:
+#        return
+
+    drop_tenure_predict_filters_from_yaml(
+        hlcm_owner_lowincome_config,
+        hlcm_owner_lowincome_no_unplaced_config)
+
+    return hlcm_simulate(households, residential_units, aggregations,
+                         settings, hlcm_owner_lowincome_no_unplaced_config,
                          "price_equilibration")
 
 
@@ -964,15 +989,35 @@ def hlcm_renter_simulate_no_unplaced(households, residential_units,
                                      hlcm_renter_no_unplaced_config):
 
     # only run in the last year, but make sure to run before summaries
-    if year != final_year:
-        return
+#    if year != final_year:
+#        return
 
-    drop_predict_filters_from_yaml(
+    drop_tenure_predict_filters_from_yaml(
         hlcm_renter_config,
         hlcm_renter_no_unplaced_config)
 
     return hlcm_simulate(households, residential_units, aggregations,
                          settings, hlcm_renter_no_unplaced_config,
+                         "rent_equilibration")
+
+
+@orca.step()
+def hlcm_renter_lowincome_simulate_no_unplaced(households, residential_units,
+                                               year, final_year,
+                                               aggregations, settings,
+                                               hlcm_renter_lowincome_config,
+                                               hlcm_renter_lowincome_no_unplaced_config):
+
+    # only run in the last year, but make sure to run before summaries
+#    if year != final_year:
+#        return
+
+    drop_tenure_predict_filters_from_yaml(
+        hlcm_renter_lowincome_config,
+        hlcm_renter_lowincome_no_unplaced_config)
+
+    return hlcm_simulate(households, residential_units, aggregations,
+                         settings, hlcm_renter_lowincome_no_unplaced_config,
                          "rent_equilibration")
 
 

--- a/configs/hlcm_owner.yaml
+++ b/configs/hlcm_owner.yaml
@@ -7,13 +7,13 @@ segmentation_col: base_income_octile
 choosers_fit_filters: (tenure == 'own' & income > 0)
 
 # filters follow the format from urbansim\urbansim\models\util.py line 21
-choosers_predict_filters: 'tenure == "own" and (base_income_quartile == 2 or base_income_quartile == 3 or base_income_quartile == 4)'
+choosers_predict_filters: (tenure == "own" and (base_income_quartile == 2 or base_income_quartile == 3 or base_income_quartile == 4))
 
 alts_fit_filters: null
 
 # filters follow the format from urbansim\urbansim\models\util.py line 21
 # do not allow non-low-income into deed-restricted units
-alts_predict_filters: 'tenure == "own" and deed_restricted == False'
+alts_predict_filters: (tenure == "own" and deed_restricted == False)
 
 interaction_predict_filters: null
 

--- a/configs/hlcm_owner.yaml
+++ b/configs/hlcm_owner.yaml
@@ -6,13 +6,14 @@ segmentation_col: base_income_octile
 
 choosers_fit_filters: (tenure == 'own' & income > 0)
 
-choosers_predict_filters: (tenure == 'own')
+# filters follow the format from urbansim\urbansim\models\util.py line 21
+choosers_predict_filters: 'tenure == "rent" and (base_income_quartile == 2 or base_income_quartile == 3 or base_income_quartile == 4)'
 
 alts_fit_filters: null
 
-alts_predict_filters: (tenure == 'own')
-#alts_predict_filters: (tenure == 'own' & deed_restricted == False)
-#alts_predict_filters: null
+# filters follow the format from urbansim\urbansim\models\util.py line 21
+# do not allow non-low-income into deed-restricted units
+alts_predict_filters: 'tenure == "own" and deed_restricted == False'
 
 interaction_predict_filters: null
 

--- a/configs/hlcm_owner.yaml
+++ b/configs/hlcm_owner.yaml
@@ -7,7 +7,7 @@ segmentation_col: base_income_octile
 choosers_fit_filters: (tenure == 'own' & income > 0)
 
 # filters follow the format from urbansim\urbansim\models\util.py line 21
-choosers_predict_filters: 'tenure == "rent" and (base_income_quartile == 2 or base_income_quartile == 3 or base_income_quartile == 4)'
+choosers_predict_filters: 'tenure == "own" and (base_income_quartile == 2 or base_income_quartile == 3 or base_income_quartile == 4)'
 
 alts_fit_filters: null
 

--- a/configs/hlcm_owner_lowincome.yaml
+++ b/configs/hlcm_owner_lowincome.yaml
@@ -8,13 +8,13 @@ segmentation_col: base_income_octile
 choosers_fit_filters: (tenure == 'own' & income > 0)
 
 # filters follow the format from urbansim\urbansim\models\util.py line 21
-choosers_predict_filters: 'tenure == "own" and base_income_quartile == 1'
+choosers_predict_filters: (tenure == "own" and base_income_quartile == 1)
 
 alts_fit_filters: null
 
 # filters follow the format from urbansim\urbansim\models\util.py line 21
 # allow low-income into deed-restricted or non-deed-restricted units
-alts_predict_filters: 'tenure == "own"'
+alts_predict_filters: (tenure == "own")
 
 interaction_predict_filters: null
 

--- a/configs/hlcm_owner_lowincome.yaml
+++ b/configs/hlcm_owner_lowincome.yaml
@@ -1,17 +1,20 @@
-name: hlcm_owner
+# a copy of hlcm_owner, no new estimation, used only to set household filters
+name: hlcm_owner_lowincome
 
 model_type: segmented_discretechoice
 
 segmentation_col: base_income_octile
 
-choosers_fit_filters: (tenure == 'own' & income > 0 & income < 30000)
+choosers_fit_filters: (tenure == 'own' & income > 0)
 
-choosers_predict_filters: (tenure == 'own')
+# filters follow the format from urbansim\urbansim\models\util.py line 21
+choosers_predict_filters: 'tenure == "own" and base_income_quartile == 1'
 
 alts_fit_filters: null
 
-#alts_predict_filters: (tenure == 'own' & deed_restricted == True)
-alts_predict_filters: null
+# filters follow the format from urbansim\urbansim\models\util.py line 21
+# allow low-income into deed-restricted or non-deed-restricted units
+alts_predict_filters: 'tenure == "own"'
 
 interaction_predict_filters: null
 

--- a/configs/hlcm_renter.yaml
+++ b/configs/hlcm_renter.yaml
@@ -7,13 +7,13 @@ segmentation_col: base_income_octile
 choosers_fit_filters: (tenure == 'rent' & income > 0)
 
 # filters follow the format from urbansim\urbansim\models\util.py line 21
-choosers_predict_filters: 'tenure == "rent" and (base_income_quartile == 2 or base_income_quartile == 3 or base_income_quartile == 4)'
+choosers_predict_filters: (tenure == "rent" and (base_income_quartile == 2 or base_income_quartile == 3 or base_income_quartile == 4))
 
 alts_fit_filters: null
 
 # filters follow the format from urbansim\urbansim\models\util.py line 21
 # do not allow non-low-income into deed-restricted units
-alts_predict_filters: 'tenure == "rent" and deed_restricted == False'
+alts_predict_filters: (tenure == "rent" and deed_restricted == False)
 
 interaction_predict_filters: null
 

--- a/configs/hlcm_renter.yaml
+++ b/configs/hlcm_renter.yaml
@@ -6,13 +6,14 @@ segmentation_col: base_income_octile
 
 choosers_fit_filters: (tenure == 'rent' & income > 0)
 
-choosers_predict_filters: (tenure == 'rent')
+# filters follow the format from urbansim\urbansim\models\util.py line 21
+choosers_predict_filters: 'tenure == "rent" and (base_income_quartile == 2 or base_income_quartile == 3 or base_income_quartile == 4)'
 
 alts_fit_filters: null
 
-alts_predict_filters: (tenure == 'rent')
-#alts_predict_filters: (tenure == 'rent' & deed_restricted == False)
-#alts_predict_filters: null
+# filters follow the format from urbansim\urbansim\models\util.py line 21
+# do not allow non-low-income into deed-restricted units
+alts_predict_filters: 'tenure == "rent" and deed_restricted == False'
 
 interaction_predict_filters: null
 

--- a/configs/hlcm_renter_lowincome.yaml
+++ b/configs/hlcm_renter_lowincome.yaml
@@ -5,7 +5,7 @@ model_type: segmented_discretechoice
 
 segmentation_col: base_income_octile
 
-choosers_fit_filters: (tenure == 'own' & income > 0)
+choosers_fit_filters: (tenure == 'rent' & income > 0)
 
 # filters follow the format from urbansim\urbansim\models\util.py line 21
 choosers_predict_filters: 'tenure == "rent" and base_income_quartile == 1'

--- a/configs/hlcm_renter_lowincome.yaml
+++ b/configs/hlcm_renter_lowincome.yaml
@@ -8,13 +8,13 @@ segmentation_col: base_income_octile
 choosers_fit_filters: (tenure == 'rent' & income > 0)
 
 # filters follow the format from urbansim\urbansim\models\util.py line 21
-choosers_predict_filters: 'tenure == "rent" and base_income_quartile == 1'
+choosers_predict_filters: (tenure == "rent" and base_income_quartile == 1)
 
 alts_fit_filters: null
 
 # filters follow the format from urbansim\urbansim\models\util.py line 21
 # allow low-income into deed-restricted or non-deed-restricted units
-alts_predict_filters: 'tenure == "rent"'
+alts_predict_filters: (tenure == "rent")
 
 interaction_predict_filters: null
 

--- a/configs/hlcm_renter_lowincome.yaml
+++ b/configs/hlcm_renter_lowincome.yaml
@@ -1,17 +1,20 @@
-name: hlcm_renter
+# a copy of hlcm_owner, no new estimation, used only to set household filters
+name: hlcm_renter_lowincome
 
 model_type: segmented_discretechoice
 
 segmentation_col: base_income_octile
 
-choosers_fit_filters: (tenure == 'rent' & income > 0 & income < 30000)
+choosers_fit_filters: (tenure == 'own' & income > 0)
 
-choosers_predict_filters: (tenure == 'rent')
+# filters follow the format from urbansim\urbansim\models\util.py line 21
+choosers_predict_filters: 'tenure == "rent" and base_income_quartile == 1'
 
 alts_fit_filters: null
 
-#alts_predict_filters: (tenure == 'rent' & deed_restricted == True)
-alts_predict_filters: null
+# filters follow the format from urbansim\urbansim\models\util.py line 21
+# allow low-income into deed-restricted or non-deed-restricted units
+alts_predict_filters: 'tenure == "rent"'
 
 interaction_predict_filters: null
 

--- a/configs/hlcm_renter_lowincome.yaml
+++ b/configs/hlcm_renter_lowincome.yaml
@@ -1,4 +1,4 @@
-# a copy of hlcm_owner, no new estimation, used only to set household filters
+# a copy of hlcm_renter, no new estimation, used only to set household filters
 name: hlcm_renter_lowincome
 
 model_type: segmented_discretechoice

--- a/configs/inputs.yaml
+++ b/configs/inputs.yaml
@@ -141,9 +141,11 @@ model_configs:
     hlcm_owner_config: hlcm_owner.yaml
     hlcm_owner_lowincome_config: hlcm_owner_lowincome.yaml
     hlcm_owner_no_unplaced_config: hlcm_owner_no_unplaced.yaml
+    hlcm_owner_lowincome_no_unplaced_config: hlcm_owner_lowincome_no_unplaced.yaml
     hlcm_renter_config: hlcm_renter.yaml
     hlcm_renter_lowincome_config: hlcm_renter_lowincome.yaml
     hlcm_renter_no_unplaced_config: hlcm_renter_no_unplaced.yaml
+    hlcm_renter_lowincome_no_unplaced_config: hlcm_renter_lowincome_no_unplaced.yaml
   elcm:
     elcm_config: elcm.yaml
   rsh:


### PR DESCRIPTION
This PR completes work that had previously been drafted to create "low income models", using HLCM configs. These essentially use existing household location choice models and add filters to them to get Q1 households specifically into deed restricted units. A few changes were needed to make this happen:
- added the model steps for low income owners and renters to the model flow
- added filters to the low income and non-low income models so that they only apply to households in those categories
- added filters so that non-low income households are not allowed in deed-restricted units, leaving these open so that the low-income households can choose them in the following model steps
- added two new "no unplaced" model steps for the two new "low income models", which create modified copies of the HLCMS in order to place any households that remain unplaced from tenure (these were running in the final simulation year)
- added all of the "no_unplaced" models to every simulation year, in case tenure placement issues come up (or the low income models affect it further). So far these models aren't needed, but they should be monitored to see if they are doing any additional placing. 

I tested these changes by running the model to 2050 with no errors. I then looked at all of the units built by the model during simulation. I confirmed that units that were deed-restricted only had Q1 households in them, and units that were not deed-restricted had all household types in them. When looking at all of the units in the model, a small number of deed-restricted units contained non-Q1 households by 2050. These are presumably non-Q1 households who occupied units marked as "deed-restricted" in the model's pre-processing step, who never moved out at which time only Q1 would be allowed to move in. 

Notes:
- While I created two new "no unplaced" models which keeps with the way the code creates them, you might be able to use fewer by making them income-agnostic. The current models add roughly 9 min of run time to the simulation. 
- I used `and` rather than `&` in the filter specifications. In this case either may work, but I used `and` as it could be safer. See: https://stackoverflow.com/questions/22646463/and-boolean-vs-bitwise-why-difference-in-behavior-with-lists-vs-nump