### PR TITLE
Specify input data type

### DIFF
--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -676,7 +676,7 @@ def get_dev_projects_table(scenario, parcels):
     # requires the user has MTC's urban_data_internal
     # repository alongside bayarea_urbansim
     urban_data_repo = ("../urban_data_internal/development_projects/")
-    current_dev_proj = ("2020_0731_1607_development_projects.csv")
+    current_dev_proj = ('2020_0902_1352_development_projects.csv')
     orca.add_injectable("dev_proj_file", current_dev_proj)
     df = pd.read_csv(os.path.join(urban_data_repo, current_dev_proj),
                      dtype={'PARCEL_ID': np.int64,

--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -256,13 +256,16 @@ def landmarks():
 @orca.table(cache=True)
 def baseyear_taz_controls():
     return pd.read_csv(os.path.join("data",
-                       "baseyear_taz_controls.csv"), index_col="taz1454")
+                                    "baseyear_taz_controls.csv"),
+                       dtype={'taz1454': np.int64}
+                       index_col="taz1454")
 
 
 @orca.table(cache=True)
 def base_year_summary_taz(mapping):
     df = pd.read_csv(os.path.join('output',
                                   'baseyear_taz_summaries_2010.csv'),
+                     dtype={'taz1454': np.int64},
                      index_col="zone_id")
     cmap = mapping["county_id_tm_map"]
     df['COUNTY_NAME'] = df.COUNTY.map(cmap)
@@ -295,6 +298,7 @@ def costar(store, parcels):
 def zoning_lookup():
     return pd.read_csv(os.path.join(misc.data_dir(),
                        "2020_06_22_zoning_lookup_hybrid_pba50.csv"),
+                       dtype={'id': np.int64},
                        index_col='id')
 
 
@@ -303,6 +307,9 @@ def zoning_lookup():
 def zoning_baseline(parcels, zoning_lookup, settings):
     df = pd.read_csv(os.path.join(misc.data_dir(),
                      "2020_06_22_zoning_parcels_hybrid_pba50.csv"),
+                     dtype={'geom_id':   np.int64,
+                            'PARCEL_ID': np.int64,
+                            'zoning_id': np.int64},
                      index_col="geom_id")
     df = pd.merge(df, zoning_lookup.to_frame(),
                   left_on="zoning_id", right_index=True)
@@ -319,9 +326,13 @@ def new_tpp_id():
 
 @orca.table(cache=True)
 def maz():
-    maz = pd.read_csv(os.path.join(misc.data_dir(), "maz_geography.csv"))
+    maz = pd.read_csv(os.path.join(misc.data_dir(), "maz_geography.csv"),
+                      dtype={'MAZ': np.int64,
+                             'TAZ': np.int64})
     maz = maz.drop_duplicates('MAZ').set_index('MAZ')
     taz1454 = pd.read_csv(os.path.join(misc.data_dir(), "maz22_taz1454.csv"),
+                          dtype={'maz':     np.int64,
+                                 'TAZ1454': np.int64},
                           index_col='maz')
     maz['taz1454'] = taz1454.TAZ1454
     return maz
@@ -330,7 +341,9 @@ def maz():
 @orca.table(cache=True)
 def parcel_to_maz():
     return pd.read_csv(os.path.join(misc.data_dir(),
-                                    "2018_05_23_parcel_to_maz22.csv"),
+                                    "2020_08_17_parcel_to_maz22.csv"),
+                       dtype={'PARCEL_ID': np.int64,
+                              'maz':       np.int64},
                        index_col="PARCEL_ID")
 
 
@@ -351,6 +364,7 @@ def county_employment_forecast():
 def taz2_forecast_inputs(regional_demographic_forecast):
     t2fi = pd.read_csv(os.path.join(misc.data_dir(),
                                     "taz2_forecast_inputs.csv"),
+                       dtype={'TAZ': np.int64},
                        index_col='TAZ').replace('#DIV/0!', np.nan)
 
     rdf = regional_demographic_forecast.to_frame()
@@ -399,6 +413,7 @@ def maz_forecast_inputs(regional_demographic_forecast):
     rdf = regional_demographic_forecast.to_frame()
     mfi = pd.read_csv(os.path.join(misc.data_dir(),
                                    "maz_forecast_inputs.csv"),
+                      dtype={'MAZ': np.int64},
                       index_col='MAZ').replace('#DIV/0!', np.nan)
 
     # apply regional share of hh by size to MAZs with no households in 2010
@@ -493,12 +508,16 @@ def parcel_rejections():
 def parcels_geography(parcels, scenario, settings):
     df = pd.read_csv(
         os.path.join(misc.data_dir(), "2020_07_10_parcels_geography.csv"),
+        dtype={'PARCEL_ID':       np.int64,
+               'geom_id':         np.int64,
+               'jurisdiction_id': np.int64},
         index_col="geom_id")
     df = geom_id_to_parcel_id(df, parcels)
 
     # this will be used to map juris id to name
     juris_name = pd.read_csv(
         os.path.join(misc.data_dir(), "census_id_to_name.csv"),
+        dtype={'census_id': np.int64},
         index_col="census_id").name10
 
     df["juris_name"] = df.jurisdiction_id.map(juris_name)
@@ -531,8 +550,9 @@ def parcels_geography(parcels, scenario, settings):
 @orca.table(cache=True)
 def parcels_subzone():
     return pd.read_csv(os.path.join(misc.data_dir(),
-                                    '2018_10_17_parcel_to_taz1454sub.csv'),
+                                    '2020_08_17_parcel_to_taz1454sub.csv'),
                        usecols=['taz_sub', 'PARCEL_ID', 'county'],
+                       dtype={'PARCEL_ID': np.int64},
                        index_col='PARCEL_ID')
 
 
@@ -658,7 +678,9 @@ def get_dev_projects_table(scenario, parcels):
     urban_data_repo = ("../urban_data_internal/development_projects/")
     current_dev_proj = ("2020_0731_1607_development_projects.csv")
     orca.add_injectable("dev_proj_file", current_dev_proj)
-    df = pd.read_csv(os.path.join(urban_data_repo, current_dev_proj))
+    df = pd.read_csv(os.path.join(urban_data_repo, current_dev_proj),
+                     dtype={'PARCEL_ID': np.int64,
+                            'geom_id':   np.int64})
     df = reprocess_dev_projects(df)
     orca.add_injectable("devproj_len", len(df))
 
@@ -839,6 +861,7 @@ def employment_controls(employment_controls_unstacked):
 def zone_forecast_inputs():
     return pd.read_csv(
         os.path.join(misc.data_dir(), "zone_forecast_inputs.csv"),
+        dtype={'zone_id': np.int64},
         index_col="zone_id")
 
 
@@ -846,6 +869,7 @@ def zone_forecast_inputs():
 def taz_forecast_inputs():
     return pd.read_csv(
         os.path.join(misc.data_dir(), "taz_forecast_inputs.csv"),
+        dtype={'TAZ1454': np.int64},
         index_col="TAZ1454")
 
 
@@ -855,6 +879,7 @@ def taz_forecast_inputs():
 def vmt_fee_categories():
     return pd.read_csv(
         os.path.join(misc.data_dir(), "vmt_fee_zonecats.csv"),
+        dtype={'taz': np.int64},
         index_col="taz")
 
 
@@ -862,6 +887,8 @@ def vmt_fee_categories():
 def superdistricts():
     return pd.read_csv(
         os.path.join(misc.data_dir(), "superdistricts.csv"),
+        dtype={'number':    np.int64,
+               'subregion': np.int64},
         index_col="number")
 
 
@@ -874,6 +901,9 @@ def abag_targets():
 def taz_geography(superdistricts, mapping):
     tg = pd.read_csv(
         os.path.join(misc.data_dir(), "taz_geography.csv"),
+        dtype={'zone':          np.int64,
+               'superdistrcit': np.int64,
+               'county':        np.int64},
         index_col="zone")
     cmap = mapping["county_id_tm_map"]
     tg['county_name'] = tg.county.map(cmap)
@@ -896,6 +926,7 @@ def taz_geography(superdistricts, mapping):
 def taz2_price_shifters():
     return pd.read_csv(os.path.join(misc.data_dir(),
                                     "taz2_price_shifters.csv"),
+                       dtype={'TAZ': np.int64},
                        index_col="TAZ")
 
 
@@ -911,6 +942,7 @@ def zones(store):
 def slr_parcel_inundation():
     return pd.read_csv(
         os.path.join(misc.data_dir(), "slr_parcel_inundation.csv"),
+        dtype={'parcel_id': np.int64},
         index_col='parcel_id')
 
 
@@ -918,6 +950,7 @@ def slr_parcel_inundation():
 def slr_parcel_inundation_mf():
     return pd.read_csv(
         os.path.join(misc.data_dir(), "slr_parcel_inundation_mf.csv"),
+        dtype={'parcel_id': np.int64},
         index_col='parcel_id')
 
 
@@ -925,6 +958,7 @@ def slr_parcel_inundation_mf():
 def slr_parcel_inundation_mp():
     return pd.read_csv(
         os.path.join(misc.data_dir(), "slr_parcel_inundation_mp.csv"),
+        dtype={'parcel_id': np.int64},
         index_col='parcel_id')
 
 
@@ -932,6 +966,7 @@ def slr_parcel_inundation_mp():
 def slr_parcel_inundation_d_b():
     return pd.read_csv(
         os.path.join(misc.data_dir(), "slr_parcel_inundation_d_b.csv"),
+        dtype={'parcel_id': np.int64},
         index_col='parcel_id')
 
 
@@ -939,6 +974,7 @@ def slr_parcel_inundation_d_b():
 def slr_parcel_inundation_d_bb():
     return pd.read_csv(
         os.path.join(misc.data_dir(), "slr_parcel_inundation_d_bb.csv"),
+        dtype={'parcel_id': np.int64},
         index_col='parcel_id')
 
 
@@ -946,6 +982,7 @@ def slr_parcel_inundation_d_bb():
 def slr_parcel_inundation_d_bp():
     return pd.read_csv(
         os.path.join(misc.data_dir(), "slr_parcel_inundation_d_bp.csv"),
+        dtype={'parcel_id': np.int64},
         index_col='parcel_id')
 
 
@@ -980,6 +1017,8 @@ def slr_progression_d_b():
 def parcels_tract():
     return pd.read_csv(
         os.path.join(misc.data_dir(), "parcel_tract_xwalk.csv"),
+        dtype={'parcel_id': np.int64,
+               'zone_id':   np.int64},
         index_col='parcel_id')
 
 


### PR DESCRIPTION
Add `dtype ={'xxx' : np.int64}` to `read_csv()` in `datasources.py` to specify the data types of key input data fields, e.g. `PARCEL_ID`, `geom_id`, `TAZ`, `TAZ1454`, `MAZ`, `jurisdiction_id`, `Zone`.

@theocharides emphasized the need to have some sort of assertion instead of letting urbansim "secretly" convert data types. So I did a test run with "2020_0731_1607_development_projects.csv" which has float64 `geom_id` and `PARCEL_ID`. The attached run log shows that `dtype ={'xxx' : np.int64}` can function as an assertion:

![image](https://user-images.githubusercontent.com/12420721/92277297-78b07200-eea7-11ea-87b7-6af26c1ba418.png)
