### PR TITLE
assign com_for_res to fee_per_sqft instead of fee_per_unit

### DIFF
--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -527,8 +527,8 @@ def topsheet(households, jobs, buildings, parcels, zones, year,
     # could be configured in settings.yaml
 
     n = buildings.vacant_res_units[buildings.vacant_res_units < 0]
-    write("Number of overfull buildings = %d" % len(n))  
-    write("Number of vacant units in overfull buildings = %d" % n.sum())   
+    write("Number of overfull buildings = %d" % len(n))
+    write("Number of vacant units in overfull buildings = %d" % n.sum())
 
     du = buildings.residential_units.sum()
     write("Number of residential units in buildings table = %d" % du)

--- a/baus/variables.py
+++ b/baus/variables.py
@@ -389,8 +389,7 @@ def fees_per_unit(parcels, policy, scenario):
     s = pd.Series(0, index=parcels.index)
 
     vmt_settings = policy["acct_settings"]["vmt_settings"]
-    if scenario in vmt_settings["com_for_res_scenarios"] or \
-            scenario in vmt_settings["res_for_res_scenarios"]:
+    if scenario in vmt_settings["res_for_res_scenarios"]:
         s += parcels.vmt_res_fees
 
     return s
@@ -402,7 +401,8 @@ def fees_per_sqft(parcels, policy, scenario):
     s = pd.Series(0, index=parcels.index)
 
     vmt_settings = policy["acct_settings"]["vmt_settings"]
-    if scenario in vmt_settings["com_for_com_scenarios"]:
+    if scenario in vmt_settings["com_for_com_scenarios"] or\
+            scenario in vmt_settings["com_for_res_scenarios"]:
         s += parcels.vmt_com_fees
 
     return s


### PR DESCRIPTION
Fixes the error of wrongly including `com_for_res` in `fees_per_unit` instead of `fees_per_sqft`. 