### PR TITLE
updated directory of dev proj to be consistent with urban_data_internal

### DIFF
--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -656,7 +656,7 @@ def get_dev_projects_table(scenario, parcels):
     # requires the user has MTC's urban_data_internal
     # repository alongside bayarea_urbansim
     urban_data_repo = ("../urban_data_internal/development_projects/")
-    current_dev_proj = ("2020_0731_1607_development_projects.csv")
+    current_dev_proj = ("2020_0914_1529_development_projects.csv")
     orca.add_injectable("dev_proj_file", current_dev_proj)
     df = pd.read_csv(os.path.join(urban_data_repo, current_dev_proj))
     df = reprocess_dev_projects(df)


### PR DESCRIPTION
@theocharides 
This PR is to make sure the datasource.py is updated to be consistent with the file in the urban_data_internal. 
https://github.com/BayAreaMetro/urban_data_internal/pull/13

The file included the following changes: 
- remove assigning HS buildings with only 1 unit (this prevents the removal of 35k units)
- residential units in ME buildings were dropped.
- assign s24 oppsites like s23
- exclude oppsites in s25, by assigning value 0