### PR TITLE
update summaries to include deed_restricted_units in parcel output

### DIFF
--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -1191,7 +1191,6 @@ def parcel_summary(parcels, buildings, households, jobs,
     df = parcels.to_frame([
         "geom_id",
         "x", "y",
-        "total_residential_units",
         "total_job_spaces",
         "first_building_type"
     ])
@@ -1224,6 +1223,15 @@ def parcel_summary(parcels, buildings, households, jobs,
             households_df.base_income_quartile == i].\
             parcel_id.value_counts()
     df["tothh"] = households_df.groupby('parcel_id').size()
+
+    building_df = orca.merge_tables(
+        'buildings',
+        [parcels, buildings],
+        columns=['parcel_id','residential_units','deed_restricted_units'])
+    df['residential_units'] = building_df.groupby('parcel_id')\
+                               ['residential_units'].sum()
+    df['deed_restricted_units'] = building_df.groupby('parcel_id')\
+                                    ['deed_restricted_units'].sum()
 
     jobs_df = orca.merge_tables(
         'jobs',


### PR DESCRIPTION
@theocharides 
I added deed restricted units into the parcel output. 
And I changed to code to get the residential unit counts from buildings table instead of parcel table - this is not really necessary. I compared the two residential unit counts, they are the same. 

This is tested with a successful round of runs. 

I am not sure how to add subsidized units into parcel output data still. 