### PR TITLE
Add DR, IZ and SU to acct log

### DIFF
--- a/baus/subsidies.py
+++ b/baus/subsidies.py
@@ -813,7 +813,7 @@ def run_subsidized_developer(feasibility, parcels, buildings, households,
                     new_buildings.loc[index,'deed_restricted_units']
             metadata['subsidized_units'] = \
                     new_buildings.loc[index,'deed_restricted_units'] - \
-                    new_buildings.loc[index,'inclusionary_units']                 
+                    new_building.inclusionary_units
             account.add_transaction(amt, subaccount=subacct,
                                     metadata=metadata)
 

--- a/baus/subsidies.py
+++ b/baus/subsidies.py
@@ -779,10 +779,9 @@ def run_subsidized_developer(feasibility, parcels, buildings, households,
                 "description": "Developing subsidized building",
                 "year": year,
                 "residential_units": new_building.residential_units,
+                "inclusionary_units": new_building.inclusionary_units,
                 "building_id": index
             }
-            account.add_transaction(amt, subaccount=subacct,
-                                    metadata=metadata)
 
             if create_deed_restricted:
 
@@ -809,6 +808,14 @@ def run_subsidized_developer(feasibility, parcels, buildings, households,
                 # also correct the debug output
                 new_buildings.loc[index, "deed_restricted_units"] =\
                     int(round(subsidized_units))
+
+            metadata['deed_restricted_units'] = \
+                    new_buildings.loc[index,'deed_restricted_units']
+            metadata['subsidized_units'] = \
+                    new_buildings.loc[index,'deed_restricted_units'] - \
+                    new_buildings.loc[index,'inclusionary_units']                 
+            account.add_transaction(amt, subaccount=subacct,
+                                    metadata=metadata)
 
         # turn off this assertion for the Draft Blueprint
         # affordable housing policy since the number of deed restricted units


### PR DESCRIPTION
This PR adds three columns - `deed_restrict_units`, `inclusionary_units`, `subsidized_units` to lump sum account tracking which eventually generates "**acct_log.csv**" for each lump sum account.

Test run:
- able to run s24 and s23 without crash
- the sum of `subsidized_units` of all lump sum accounts' "**acct_log.csv**" equals the total `subsidized_units' in "**superdistrict_summaries.csv**"
- the sum of `inclusionary_units` and the sum of `deed_restricted_units` of all lump sum accounts are smaller than the numbers in "**superdistrict_summaries.csv**", this is because "**acct_log.csv**" doesn't include buildings not subsidized by lump sum accounts.