### PR TITLE
Fb reduce dev cost strategy

### DIFF
--- a/baus/subsidies.py
+++ b/baus/subsidies.py
@@ -411,6 +411,7 @@ def policy_modifications_of_profit(feasibility, parcels):
 
                 print("Modifying profit for %s:\n" % policy["name"],
                       pct_modifications.describe())
+                print("Formula: \n{}".format(formula))
 
                 feasibility[("residential", "max_profit")] *= pct_modifications
 

--- a/baus/subsidies.py
+++ b/baus/subsidies.py
@@ -398,6 +398,10 @@ def policy_modifications_of_profit(feasibility, parcels):
                         orca.get_injectable("scenario") in \
                         policy["alternate_geography_scenarios"]:
                     formula = policy["alternate_adjustment_formula"]
+                elif "geography_scenarios_fb" in policy and \
+                        orca.get_injectable("scenario") in \
+                        policy["geography_scenarios_fb"]:
+                    formula = policy["profitability_adjustment_formula_fb"]
                 else:
                     formula = policy["profitability_adjustment_formula"]
 

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -141,6 +141,13 @@ def config(policy, inputs, run_number, scenario, parcels,
                 "alternate_buildings_filter" in policy_loc else \
                 policy_loc["alternate_adjustment_formula"]
             write(policy_nm+" is activated with formula: {}".format(geog))
+        if scenario in policy_loc["enable_in_scenarios"] \
+                and "geography_scenarios_fb" in policy_loc \
+                and scenario in policy_loc["geography_scenarios_fb"]:
+            geog = policy_loc["receiving_buildings_filter_fb"] if \
+                "receiving_buildings_filter_fb" in policy_loc else \
+                policy_loc["profitability_adjustment_formula_fb"]
+            write(policy_nm+" is activated with formula: {}".format(geog))
         elif scenario in policy_loc["enable_in_scenarios"]:
             geog = policy_loc["receiving_buildings_filter"] if \
                 "receiving_buildings_filter" in policy_loc else \
@@ -178,20 +185,20 @@ def config(policy, inputs, run_number, scenario, parcels,
     # Reduce housing development cost
     policy_loc = (policy["acct_settings"]
                   ["profitability_adjustment_policies"]
-                  ["reduce_housing_costs_tier_1_market_rate_developer"])
-    policy_nm = "Reduce Housing Cost Tier 1 for Market-rate Developers"
+                  ["reduce_housing_costs_tier_1"])
+    policy_nm = "Reduce Housing Cost Tier 1: -2.5%"
     policy_activated(policy_loc, policy_nm, scenario)
 
     policy_loc = (policy["acct_settings"]
                   ["profitability_adjustment_policies"]
-                  ["reduce_housing_costs_tier_2_market_rate_developer"])
-    policy_nm = "Reduce Housing Cost Tier 2 for Market-rate Developers"
+                  ["reduce_housing_costs_tier_2"])
+    policy_nm = "Reduce Housing Cost Tier 2: -1.9%"
     policy_activated(policy_loc, policy_nm, scenario)
 
     policy_loc = (policy["acct_settings"]
                   ["profitability_adjustment_policies"]
-                  ["reduce_housing_costs_tier_3_market_rate_developer"])
-    policy_nm = "Reduce Housing Cost Tier 3 for Market-rate Developers"
+                  ["reduce_housing_costs_tier_3"])
+    policy_nm = "Reduce Housing Cost Tier 3: -1.3%"
     policy_activated(policy_loc, policy_nm, scenario)
     write("")
 

--- a/configs/policy.yaml
+++ b/configs/policy.yaml
@@ -1619,8 +1619,8 @@ acct_settings:
                                           jurisdiction_id == 53000 or
                                           jurisdiction_id == 68000) * .01"
 
-    reduce_housing_costs_tier_1_market_rate_developer:
-      name: "Reduce Cost - Market Rate Developer - Tier 1: -2.5%"
+    reduce_housing_costs_tier_1:
+      name: "Reduce Cost Tier 1: -2.5%"
       enable_in_scenarios: ["20", "21", "22", "23", "24"]
       # GG + TRA1 + HRA or GG + TRA2 + HRA
       profitability_adjustment_formula: "(gg_id == 'GG' &
@@ -1639,23 +1639,21 @@ acct_settings:
                                      sesit_id == 'HRA' &
                                      ppa_id == '') * .025"
       geography_scenarios_fb: ["24"]
-      profitability_adjustment_formula_fb: "(gg_id > '' 
-                                             and 
-                                             (
-                                               tra_id == 'tra1' 
-                                               or tra_id == 'tra2a' 
-                                               or tra_id == 'tra2b' 
-                                               or tra_id == 'tra2c'
-                                             )
-                                             and 
-                                             (
-                                               sesit_id == 'hra' 
-                                               or sesit_id == 'hradis'
-                                             )
-                                             and ppa_id == '') * .025"
-
-    reduce_housing_costs_tier_2_market_rate_developer:
-      name: "Reduce Cost - Market Rate Developer - Tier 2: -1.9%"
+      profitability_adjustment_formula_fb: "(gg_id > ''
+                                            and
+                                            (
+                                              tra_id == 'tra1'
+                                              or tra_id == 'tra2a'
+                                              or tra_id == 'tra2b'
+                                              or tra_id == 'tra2c'
+                                            )
+                                            and
+                                            (
+                                              sesit_id == 'hra'
+                                              or sesit_id == 'hradis'
+                                            )) * .025"
+    reduce_housing_costs_tier_2:
+      name: "Reduce Cost Tier 2: -1.9%"
       enable_in_scenarios: ["20", "21", "22", "23", "24"]
       # GG + TRA1 or GG + TRA3 + HRA
       profitability_adjustment_formula: "((gg_id == 'GG' &
@@ -1680,24 +1678,25 @@ acct_settings:
                                       sesit_id == 'HRA' &
                                       ppa_id == '')) * .019"
       geography_scenarios_fb: ["24"]
-      profitability_adjustment_formula_fb: "((gg_id > '' 
-                                             and tra_id == 'tra1' 
-                                             and sesit_id == '' 
-                                             and ppa_id == '' ) 
-                                             or 
-                                             (
-                                               gg_id > '' 
-                                               and tra_id == 'tra3' 
-                                               and 
-                                               (
-                                                 sesit_id == 'hra' 
-                                                 or sesit_id == 'hradis'
-                                               )
-                                               and ppa_id == ''
-                                             )) * .019"
+      profitability_adjustment_formula_fb: "((gg_id > ''
+                                            and tra_id == 'tra1'
+                                            and 
+                                            (
+                                              sesit_id == ''
+                                              or sesit_id == 'dis'
+                                            ))
+                                            or
+                                            (
+                                              gg_id > ''
+                                              and tra_id == 'tra3'
+                                              and
+                                              (
+                                                sesit_id == 'hra'
+                                                or sesit_id == 'hradis'
+                                              ))) * .019"
 
-    reduce_housing_costs_tier_3_market_rate_developer:
-      name: "Reduce Cost - Market Rate Developer - Tier 3: -1.3%"
+    reduce_housing_costs_tier_3:
+      name: "Reduce Cost Tier 3: -1.3%"
       enable_in_scenarios: ["20", "21", "22", "23", "24"]
       # GG + TRA3 or GG + HRA
       profitability_adjustment_formula: "((gg_id == 'GG' &
@@ -1721,20 +1720,22 @@ acct_settings:
                                       ppa_id == '')) * .013"
       geography_scenarios_fb: ["24"]
       profitability_adjustment_formula_fb: "((gg_id > ''
-                                             and tra_id == 'tra3'
-                                             and sesit_id == '' 
-                                             and ppa_id == '' )
-                                             or
-                                             (
-                                             (gg_id > ''
-                                               and tra_id == ''
-                                               and
-                                               (
-                                                   sesit_id == 'hra'
-                                                   or sesit_id == 'hradis'
-                                               )
-                                               and ppa_id == '')) * .013"
-                                                                           
+                                            and tra_id == 'tra3'
+                                            and
+                                            (
+                                              sesit_id == ''
+                                              or sesit_id == 'dis'
+                                            ))
+                                            or
+                                            (
+                                              gg_id > ''
+                                              and tra_id == ''
+                                              and
+                                              (
+                                                sesit_id == 'hra'
+                                                or sesit_id == 'hradis'
+                                              ))) * .013"
+
   # this is a cutom policy which taxes land (reduces profit) based on the current
   # built density - this is to incentive using land at its highest and best use
   land_value_tax_settings:

--- a/configs/policy.yaml
+++ b/configs/policy.yaml
@@ -1623,20 +1623,20 @@ acct_settings:
       name: "Reduce Cost Tier 1: -2.5%"
       enable_in_scenarios: ["20", "21", "22", "23", "24"]
       # GG + TRA1 + HRA or GG + TRA2 + HRA
-      profitability_adjustment_formula: "(gg_id == 'GG' &
+      profitability_adjustment_formula: "(gg_id > '' &
                                          (tra_id == 'tra1' |
                                           tra_id == 'tra2' |
                                           tra_id == 'tra2c1') &
-                                         sesit_id == 'HRA' &
+                                         sesit_id == 'hra' &
                                          ppa_id == '') * .025"
       alternate_geography_scenarios: ["23"]
-      alternate_adjustment_formula: "(gg_id == 'GG' &
+      alternate_adjustment_formula: "(gg_id > '' &
                                      (tra_id == 'tra1' |
                                       tra_id == 'tra2c1' |
                                       tra_id == 'tra3c1' |
                                       tra_id == 'tra2' |
                                       tra_id == 'tra3c2') &
-                                     sesit_id == 'HRA' &
+                                     sesit_id == 'hra' &
                                      ppa_id == '') * .025"
       geography_scenarios_fb: ["24"]
       profitability_adjustment_formula_fb: "(gg_id > ''
@@ -1656,26 +1656,26 @@ acct_settings:
       name: "Reduce Cost Tier 2: -1.9%"
       enable_in_scenarios: ["20", "21", "22", "23", "24"]
       # GG + TRA1 or GG + TRA3 + HRA
-      profitability_adjustment_formula: "((gg_id == 'GG' &
+      profitability_adjustment_formula: "((gg_id > '' &
                                            tra_id == 'tra1' &
                                            sesit_id == '' &
                                            ppa_id == '') |
-                                          (gg_id == 'GG' &
+                                          (gg_id > '' &
                                           (tra_id == 'tra3' |
                                            tra_id == 'tra3c2' |
                                            tra_id == 'tra3c1') &
-                                          sesit_id == 'HRA' &
+                                          sesit_id == 'hra' &
                                           ppa_id == '')) * .019"
       alternate_geography_scenarios: ["23"]
-      alternate_adjustment_formula: "((gg_id == 'GG' &
+      alternate_adjustment_formula: "((gg_id > '' &
                                       (tra_id == 'tra1'|
                                        tra_id == 'tra2c1' |
                                        tra_id == 'tra3c1') &
                                       sesit_id == '' &
                                       ppa_id == '') |
-                                     (gg_id == 'GG' &
+                                     (gg_id > '' &
                                       tra_id == 'tra3' &
-                                      sesit_id == 'HRA' &
+                                      sesit_id == 'hra' &
                                       ppa_id == '')) * .019"
       geography_scenarios_fb: ["24"]
       profitability_adjustment_formula_fb: "((gg_id > ''
@@ -1699,24 +1699,24 @@ acct_settings:
       name: "Reduce Cost Tier 3: -1.3%"
       enable_in_scenarios: ["20", "21", "22", "23", "24"]
       # GG + TRA3 or GG + HRA
-      profitability_adjustment_formula: "((gg_id == 'GG' &
+      profitability_adjustment_formula: "((gg_id > '' &
                                           (tra_id == 'tra3'|
                                            tra_id == 'tra3c1' |
                                            tra_id == 'tra3c1') &
                                           sesit_id == '' &
                                           ppa_id == '') |
-                                         (gg_id == 'GG' &
+                                         (gg_id > '' &
                                           tra_id == '' &
-                                          sesit_id == 'HRA' &
+                                          sesit_id == 'hra' &
                                           ppa_id == '')) * .013"
       alternate_geography_scenarios: ["23"]
-      alternate_adjustment_formula: "((gg_id == 'GG' &
+      alternate_adjustment_formula: "((gg_id > '' &
                                       tra_id == 'tra3' &
                                       sesit_id == '' &
                                       ppa_id == '') |
-                                     (gg_id == 'GG' &
+                                     (gg_id > '' &
                                       tra_id == '' &
-                                      sesit_id == 'HRA' &
+                                      sesit_id == 'hra' &
                                       ppa_id == '')) * .013"
       geography_scenarios_fb: ["24"]
       profitability_adjustment_formula_fb: "((gg_id > ''

--- a/configs/policy.yaml
+++ b/configs/policy.yaml
@@ -1621,7 +1621,7 @@ acct_settings:
 
     reduce_housing_costs_tier_1_market_rate_developer:
       name: "Reduce Cost - Market Rate Developer - Tier 1: -2.5%"
-      enable_in_scenarios: ["20", "21", "22", "23"]
+      enable_in_scenarios: ["20", "21", "22", "23", "24"]
       # GG + TRA1 + HRA or GG + TRA2 + HRA
       profitability_adjustment_formula: "(gg_id == 'GG' &
                                          (tra_id == 'tra1' |
@@ -1638,10 +1638,25 @@ acct_settings:
                                       tra_id == 'tra3c2') &
                                      sesit_id == 'HRA' &
                                      ppa_id == '') * .025"
+      geography_scenarios_fb: ["24"]
+      profitability_adjustment_formula_fb: "(gg_id > '' 
+                                             and 
+                                             (
+                                               tra_id == 'tra1' 
+                                               or tra_id == 'tra2a' 
+                                               or tra_id == 'tra2b' 
+                                               or tra_id == 'tra2c'
+                                             )
+                                             and 
+                                             (
+                                               sesit_id == 'hra' 
+                                               or sesit_id == 'hradis'
+                                             )
+                                             and ppa_id == '') * .025"
 
     reduce_housing_costs_tier_2_market_rate_developer:
       name: "Reduce Cost - Market Rate Developer - Tier 2: -1.9%"
-      enable_in_scenarios: ["20", "21", "22", "23"]
+      enable_in_scenarios: ["20", "21", "22", "23", "24"]
       # GG + TRA1 or GG + TRA3 + HRA
       profitability_adjustment_formula: "((gg_id == 'GG' &
                                            tra_id == 'tra1' &
@@ -1664,10 +1679,26 @@ acct_settings:
                                       tra_id == 'tra3' &
                                       sesit_id == 'HRA' &
                                       ppa_id == '')) * .019"
+      geography_scenarios_fb: ["24"]
+      profitability_adjustment_formula_fb: "((gg_id > '' 
+                                             and tra_id == 'tra1' 
+                                             and sesit_id == '' 
+                                             and ppa_id == '' ) 
+                                             or 
+                                             (
+                                               gg_id > '' 
+                                               and tra_id == 'tra3' 
+                                               and 
+                                               (
+                                                 sesit_id == 'hra' 
+                                                 or sesit_id == 'hradis'
+                                               )
+                                               and ppa_id == ''
+                                             )) * .019"
 
     reduce_housing_costs_tier_3_market_rate_developer:
       name: "Reduce Cost - Market Rate Developer - Tier 3: -1.3%"
-      enable_in_scenarios: ["20", "21", "22", "23"]
+      enable_in_scenarios: ["20", "21", "22", "23", "24"]
       # GG + TRA3 or GG + HRA
       profitability_adjustment_formula: "((gg_id == 'GG' &
                                           (tra_id == 'tra3'|
@@ -1688,6 +1719,21 @@ acct_settings:
                                       tra_id == '' &
                                       sesit_id == 'HRA' &
                                       ppa_id == '')) * .013"
+      geography_scenarios_fb: ["24"]
+      profitability_adjustment_formula_fb: "((gg_id > ''
+                                             and tra_id == 'tra3'
+                                             and sesit_id == '' 
+                                             and ppa_id == '' )
+                                             or
+                                             (
+                                             (gg_id > ''
+                                               and tra_id == ''
+                                               and
+                                               (
+                                                   sesit_id == 'hra'
+                                                   or sesit_id == 'hradis'
+                                               )
+                                               and ppa_id == '')) * .013"
                                                                            
   # this is a cutom policy which taxes land (reduces profit) based on the current
   # built density - this is to incentive using land at its highest and best use


### PR DESCRIPTION
Changes:

- Added the strategy for s24.

- updated the policy setting for s23 because recent code change has changed the 'gg_id' field of `parcels_geography`.

Was able to run through year 2050 with no error. 
Compared with September release result, this strategy increased residential unit count by 150. The number is small, likely due to the fact that only a small portion of parcels fall into the cost reduction categories: 4.4% of all parcels fall into tier 1, 4.4% fall into tier 2, 2.0% fall into tier 3. The scale of cost reduction is also relatively limited: profitability increases by 2.5% for tier 1 projects, by 1.9% for tier 2 projects, and by 1.3% for tier 3 projects.
Considering these factors, I think the result makes sense. 