### PR TITLE
Final Blueprint inclusionary strategy + new 'inclusionary_units' column in 'buildings'

### DIFF
--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -744,6 +744,7 @@ def development_projects(parcels, mapping, scenario):
     df["non_residential_sqft"] = df.non_residential_sqft.fillna(0)
     df["residential_units"] = df.residential_units.fillna(0).astype("int")
     df["preserved_units"] = 0.0
+    df["inclusionary_units"] = 0.0
 
     df["building_type"] = df.building_type.replace("HP", "OF")
     df["building_type"] = df.building_type.replace("GV", "OF")

--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -133,8 +133,8 @@ def inclusionary_housing_settings(policy, scenario):
     d = {}
     if (scenario in policy["inclusionary_d_b_enable"]):
         for item in s:
-            # this is a list of Blueprint strategy geographies - represented
-            # by pba50chcat - with an inclusionary rate that is the same
+            # this is a list of draft blueprint strategy geographies (represented
+            # by pba50chcat) with an inclusionary rate that is the same
             # for all the pba50chcats in the list
             print("Setting inclusionary rates for geographies %d pba50chcat \
                   to %.2f" % (len(item["values"]), item["amount"]))
@@ -143,6 +143,18 @@ def inclusionary_housing_settings(policy, scenario):
             # of pba50chcat names to rates
             for pba50chcat in item["values"]:
                 d[pba50chcat] = item["amount"]
+    elif (scenario in policy["inclusionary_fb_enable"]):
+        for item in s:
+            # this is a list of final blueprint strategy geographies (represented
+            # by fbpchcat) with an inclusionary rate that is the same
+            # for all the fbpchcat in the list
+            print("Setting inclusionary rates for geographies %d fbpchcat \
+                  to %.2f" % (len(item["values"]), item["amount"]))
+            # this is a list of inclusionary rates and the fbpchcat
+            # geographies they apply to - need to turn it in a map
+            # of fbpchcat names to rates
+            for fbpchcat in item["values"]:
+                d[fbpchcat] = item["amount"]
     else:
         for item in s:
             # this is a list of cities with an inclusionary rate that is the

--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -744,7 +744,6 @@ def development_projects(parcels, mapping, scenario):
     df["non_residential_sqft"] = df.non_residential_sqft.fillna(0)
     df["residential_units"] = df.residential_units.fillna(0).astype("int")
     df["preserved_units"] = 0.0
-    df["inclusionary_units"] = 0.0
 
     df["building_type"] = df.building_type.replace("HP", "OF")
     df["building_type"] = df.building_type.replace("GV", "OF")

--- a/baus/models.py
+++ b/baus/models.py
@@ -509,12 +509,6 @@ def add_extra_columns_func(df):
               df.deed_restricted_units.sum())
     df["preserved_units"] = 0.0
 
-    if "inclusionary_units" not in df.columns:
-        df["inclusionary_units"] = 0
-    else:
-        print("Number of inclusionary units built = %d" %
-              df.inclusionary_units.sum())
-
     df["redfin_sale_year"] = 2012
     df["redfin_sale_price"] = np.nan
 
@@ -629,8 +623,7 @@ def residential_developer(feasibility, households, buildings, parcels, year,
         # again because the buildings df gets modified by the run_developer
         # method below
         buildings = orca.get_table('buildings')
-        print('Stats of buildings before run_developer(): \n{}'.format(
-             buildings.to_frame()[['deed_restricted_units','preserved_units','inclusionary_units']].sum()))
+
         new_buildings = utils.run_developer(
             "residential",
             households,
@@ -646,8 +639,6 @@ def residential_developer(feasibility, households, buildings, parcels, year,
             num_units_to_build=int(target),
             profit_to_prob_func=subsidies.profit_to_prob_func,
             **kwargs)
-        print('Stats of buildings before run_developer(): \n{}'.format(
-             buildings.to_frame()[['deed_restricted_units','preserved_units','inclusionary_units']].sum()))
 
         buildings = orca.get_table('buildings')
 
@@ -673,7 +664,7 @@ def residential_developer(feasibility, households, buildings, parcels, year,
 
                 # we also need to fix the other columns so they make sense
                 for col in ["residential_sqft", "building_sqft",
-                            "deed_restricted_units", "inclusionary_units"]:
+                            "deed_restricted_units"]:
                     val = buildings.local.loc[index, col]
                     # reduce by pct but round to int
                     buildings.local.loc[index, col] = int(val * overshoot_pct)

--- a/baus/models.py
+++ b/baus/models.py
@@ -509,6 +509,12 @@ def add_extra_columns_func(df):
               df.deed_restricted_units.sum())
     df["preserved_units"] = 0.0
 
+    if "inclusionary_units" not in df.columns:
+        df["inclusionary_units"] = 0
+    else:
+        print("Number of inclusionary units built = %d" %
+              df.inclusionary_units.sum())
+
     df["redfin_sale_year"] = 2012
     df["redfin_sale_price"] = np.nan
 
@@ -623,7 +629,8 @@ def residential_developer(feasibility, households, buildings, parcels, year,
         # again because the buildings df gets modified by the run_developer
         # method below
         buildings = orca.get_table('buildings')
-
+        print('Stats of buildings before run_developer(): \n{}'.format(
+             buildings.to_frame()[['deed_restricted_units','preserved_units','inclusionary_units']].sum()))
         new_buildings = utils.run_developer(
             "residential",
             households,
@@ -639,6 +646,8 @@ def residential_developer(feasibility, households, buildings, parcels, year,
             num_units_to_build=int(target),
             profit_to_prob_func=subsidies.profit_to_prob_func,
             **kwargs)
+        print('Stats of buildings before run_developer(): \n{}'.format(
+             buildings.to_frame()[['deed_restricted_units','preserved_units','inclusionary_units']].sum()))
 
         buildings = orca.get_table('buildings')
 
@@ -664,7 +673,7 @@ def residential_developer(feasibility, households, buildings, parcels, year,
 
                 # we also need to fix the other columns so they make sense
                 for col in ["residential_sqft", "building_sqft",
-                            "deed_restricted_units"]:
+                            "deed_restricted_units", "inclusionary_units"]:
                     val = buildings.local.loc[index, col]
                     # reduce by pct but round to int
                     buildings.local.loc[index, col] = int(val * overshoot_pct)

--- a/baus/models.py
+++ b/baus/models.py
@@ -677,6 +677,16 @@ def residential_developer(feasibility, households, buildings, parcels, year,
                     val = buildings.local.loc[index, col]
                     # reduce by pct but round to int
                     buildings.local.loc[index, col] = int(val * overshoot_pct)
+                # also fix the corresponding columns in new_buildings
+                for col in ["residential_sqft","building_sqft",
+                            "residential_units", "deed_restricted_units",
+                            "inclusionary_units"]:
+                    val = new_buildings.loc[index, col]
+                    new_buildings.loc[index, col] = int(val * overshoot_pct)
+                for col in ["inclusionary_revenue_reduction",
+                            "total_subsidy"]:
+                    val = new_buildings.loc[index, col]
+                    new_buildings.loc[index, col] = val * overshoot_pct
 
         summary.add_parcel_output(new_buildings)
 

--- a/baus/models.py
+++ b/baus/models.py
@@ -920,6 +920,7 @@ def developer_reprocess(buildings, year, years_per_iter, jobs,
     new_buildings["residential_units"] = 0
     new_buildings["residential_sqft"] = 0
     new_buildings["deed_restricted_units"] = 0
+    new_buildings["inclusionary_units"] = 0
     new_buildings["building_sqft"] = new_buildings.non_residential_sqft
     new_buildings["stories"] = 1
     new_buildings["building_type"] = "RB"

--- a/baus/models.py
+++ b/baus/models.py
@@ -683,8 +683,8 @@ def residential_developer(feasibility, households, buildings, parcels, year,
                             "inclusionary_units"]:
                     val = new_buildings.loc[index, col]
                     new_buildings.loc[index, col] = int(val * overshoot_pct)
-                for col in ["inclusionary_revenue_reduction",
-                            "total_subsidy"]:
+                for col in ["policy_based_revenue_reduction",
+                            "max_profit"]:
                     val = new_buildings.loc[index, col]
                     new_buildings.loc[index, col] = val * overshoot_pct
 

--- a/baus/preprocessing.py
+++ b/baus/preprocessing.py
@@ -294,6 +294,7 @@ def preproc_buildings(store, parcels, manual_edits):
         axis=1).max(axis=1)
 
     df["preserved_units"] = 0.0
+    df["inclusionary_units"] = 0.0
 
     # XXX need to make sure jobs don't exceed capacity
 

--- a/baus/preprocessing.py
+++ b/baus/preprocessing.py
@@ -294,7 +294,6 @@ def preproc_buildings(store, parcels, manual_edits):
         axis=1).max(axis=1)
 
     df["preserved_units"] = 0.0
-    df["inclusionary_units"] = 0.0
 
     # XXX need to make sure jobs don't exceed capacity
 

--- a/baus/subsidies.py
+++ b/baus/subsidies.py
@@ -211,6 +211,13 @@ def inclusionary_housing_revenue_reduction(feasibility, units):
                                        "income",
                                        "pba50chcat"])
         AMI = h.groupby(h.pba50chcat).income.quantile(.5)
+    elif orca.get_injectable("scenario") in policy["inclusionary_fb_enable"]:
+        h = orca.merge_tables("households",
+                              [households, buildings, parcels_geography],
+                              columns=["juris_name",
+                                       "income",
+                                       "fbpchcat"])
+        AMI = h.groupby(h.fbpchcat).income.quantile(.5)
     else:
         h = orca.merge_tables("households",
                               [households, buildings, parcels_geography],
@@ -244,8 +251,8 @@ def inclusionary_housing_revenue_reduction(feasibility, units):
 
     pct_inclusionary = orca.get_injectable("inclusionary_housing_settings")
 
-    # for Blueprint scenarios, calculate revenue reduction by
-    # Blueprint strategy geogrphies pba50chcat
+    # for PBA50, calculate revenue reduction by strategy geographies
+    # draft blueprint strategy geography: pba50chcat
     if orca.get_injectable("scenario") in policy["inclusionary_d_b_enable"]:
         pba50chcat = parcels_geography.pba50chcat.loc[feasibility.index]
         pct_affordable = pba50chcat.map(pct_inclusionary).fillna(0)
@@ -264,7 +271,29 @@ def inclusionary_housing_revenue_reduction(feasibility, units):
         revenue_reduction = revenue_diff_per_unit * num_affordable_units
 
         s = num_affordable_units.groupby(parcels_geography.pba50chcat).sum()
-        print("Feasibile affordable units by Blueprint geogrphies pba50chcat")
+        print("Feasibile affordable units by Draft Blueprint pba50chcat")
+        print(s[s > 0].sort_values())
+
+    # final blueprint strategy geogrphy: fbpchcat
+    elif orca.get_injectable("scenario") in policy["inclusionary_fb_enable"]:
+        fbpchcat = parcels_geography.fbpchcat.loc[feasibility.index]
+        pct_affordable = fbpchcat.map(pct_inclusionary).fillna(0)
+        value_can_afford = fbpchcat.map(value_can_afford)
+
+        num_affordable_units = (units * pct_affordable).fillna(0).astype("int")
+
+        ave_price_per_unit = \
+            feasibility[('residential', 'building_revenue')] / units
+
+        revenue_diff_per_unit = \
+            (ave_price_per_unit - value_can_afford).fillna(0)
+        print("Revenue difference per unit (not zero values)")
+        print(revenue_diff_per_unit[revenue_diff_per_unit > 0].describe())
+
+        revenue_reduction = revenue_diff_per_unit * num_affordable_units
+
+        s = num_affordable_units.groupby(parcels_geography.fbpchcat).sum()
+        print("Feasibile affordable units by Final Blueprint fbpchcat")
         print(s[s > 0].sort_values())
 
     # otherwise, calculate by jurisdiction

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -965,8 +965,9 @@ def geographic_summary(parcels, households, jobs, buildings, taz_geography,
         'buildings',
         [parcels, buildings],
         columns=['pda_pba40', 'pda_pba50', 'superdistrict', 'juris',
-                 'building_type', 'zone_id', 'residential_units', 
-                 'preserved_units', 'building_sqft', 'non_residential_sqft',
+                 'building_type', 'zone_id', 'residential_units',
+                 'preserved_units', 'inclusionary_units',
+                 'building_sqft', 'non_residential_sqft',
                  'juris_trich', 'juris_tra', 'juris_sesit', 'juris_ppa'])
 
     parcel_output = summary.parcel_output
@@ -1096,6 +1097,12 @@ def geographic_summary(parcels, households, jobs, buildings, taz_geography,
             summary_table['preserved_units'] = buildings_df.\
             	groupby(geography).preserved_units.sum()
 
+            summary_table['deed_restricted_units_blg'] = buildings_df.\
+                groupby(geography).deed_restricted_units.sum()
+
+            summary_table['inclusionary_units_blg'] = buildings_df.\
+                groupby(geography).inclusionary_units.sum()           
+
             summary_table = summary_table.sort_index()
 
             if base is False:
@@ -1205,9 +1212,10 @@ def building_summary(parcels, run_number, year,
         'buildings',
         [parcels, buildings],
         columns=['performance_zone', 'year_built', 'building_type',
-                 'residential_units', 'unit_price', 'zone_id', 
-                 'non_residential_sqft', 'vacant_res_units', 
-                 'deed_restricted_units', 'preserved_units', 'job_spaces', 
+                 'residential_units', 'unit_price', 'zone_id',
+                 'non_residential_sqft', 'vacant_res_units',
+                 'deed_restricted_units', 'inclusionary_units',
+                 'preserved_units', 'job_spaces', 
                  'x', 'y', 'geom_id', 'source'])
 
     df.to_csv(
@@ -1246,7 +1254,7 @@ def parcel_summary(parcels, buildings, households, jobs,
         join_col = "pba50chcat"
     elif scenario in policy["geographies_fb_enable"]:
         join_col = "fbpchcat"
-    elif scenario in policy["geographies_pba40_enable"]s:
+    elif scenario in policy["geographies_pba40_enable"]:
         join_col = 'zoningmodcat'
     else:
         join_col = 'zoninghzcat'

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -238,6 +238,10 @@ def config(policy, inputs, run_number, scenario, parcels,
         for item in s[scenario]:
             write("Inclusionary rates for %d pba50chcat are set to %.2f" %
                   (len(item["values"]), item["amount"]))
+    elif scenario in policy["inclusionary_fb_enable"]:
+        for item in s[scenario]:
+            write("Inclusionary rates for %d fbpchcat are set to %.2f" %
+                  (len(item["values"]), item["amount"]))
     elif scenario in s.keys():
         for item in s[scenario]:
             write("Inclusionary rates for %d cities are set to %.2f" %

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -965,9 +965,8 @@ def geographic_summary(parcels, households, jobs, buildings, taz_geography,
         'buildings',
         [parcels, buildings],
         columns=['pda_pba40', 'pda_pba50', 'superdistrict', 'juris',
-                 'building_type', 'zone_id', 'residential_units',
-                 'preserved_units', 'inclusionary_units',
-                 'building_sqft', 'non_residential_sqft',
+                 'building_type', 'zone_id', 'residential_units', 
+                 'preserved_units', 'building_sqft', 'non_residential_sqft',
                  'juris_trich', 'juris_tra', 'juris_sesit', 'juris_ppa'])
 
     parcel_output = summary.parcel_output
@@ -1097,12 +1096,6 @@ def geographic_summary(parcels, households, jobs, buildings, taz_geography,
             summary_table['preserved_units'] = buildings_df.\
             	groupby(geography).preserved_units.sum()
 
-            summary_table['deed_restricted_units_blg'] = buildings_df.\
-                groupby(geography).deed_restricted_units.sum()
-
-            summary_table['inclusionary_units_blg'] = buildings_df.\
-                groupby(geography).inclusionary_units.sum()           
-
             summary_table = summary_table.sort_index()
 
             if base is False:
@@ -1212,10 +1205,9 @@ def building_summary(parcels, run_number, year,
         'buildings',
         [parcels, buildings],
         columns=['performance_zone', 'year_built', 'building_type',
-                 'residential_units', 'unit_price', 'zone_id',
-                 'non_residential_sqft', 'vacant_res_units',
-                 'deed_restricted_units', 'inclusionary_units',
-                 'preserved_units', 'job_spaces', 
+                 'residential_units', 'unit_price', 'zone_id', 
+                 'non_residential_sqft', 'vacant_res_units', 
+                 'deed_restricted_units', 'preserved_units', 'job_spaces', 
                  'x', 'y', 'geom_id', 'source'])
 
     df.to_csv(
@@ -1254,7 +1246,7 @@ def parcel_summary(parcels, buildings, households, jobs,
         join_col = "pba50chcat"
     elif scenario in policy["geographies_fb_enable"]:
         join_col = "fbpchcat"
-    elif scenario in policy["geographies_pba40_enable"]:
+    elif scenario in policy["geographies_pba40_enable"]s:
         join_col = 'zoningmodcat'
     else:
         join_col = 'zoninghzcat'

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -1078,10 +1078,6 @@ def geographic_summary(parcels, households, jobs, buildings, taz_geography,
                 groupby(geography).preserved_units.sum()
             summary_table['inclusionary_units'] = buildings_df.\
                 groupby(geography).inclusionary_units.sum()
-            summary_table['subsidized_units'] = \
-                summary_table['deed_restricted_units'] - \
-                summary_table['preserved_units'] - \
-                summary_table['inclusionary_units']
 
             # additional columns from parcel_output
             if parcel_output is not None:
@@ -1090,8 +1086,6 @@ def geographic_summary(parcels, households, jobs, buildings, taz_geography,
                     parcel_output.inclusionary_units
 
                 # columns re: affordable housing
-                summary_table['inclusionary_units'] = \
-                    parcel_output.groupby(geography).inclusionary_units.sum()
                 summary_table['subsidized_units'] = \
                     parcel_output.groupby(geography).subsidized_units.sum()
                 summary_table['inclusionary_revenue_reduction'] = \

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -1264,14 +1264,7 @@ def parcel_summary(parcels, buildings, households, jobs,
     df = df.join(df2)
 
     # bringing in zoning modifications growth geography tag
-    if scenario in policy["geographies_db_enable"]:
-        join_col = "pba50chcat"
-    elif scenario in policy["geographies_fb_enable"]:
-        join_col = "fbpchcat"
-    elif scenario in policy["geographies_pba40_enable"]:
-        join_col = 'zoningmodcat'
-    else:
-        join_col = 'zoninghzcat'
+    join_col = "fbpchcat"
     if join_col in parcels_geography.to_frame().columns:
         parcel_gg = parcels_geography.to_frame([
             "parcel_id",

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -1220,7 +1220,8 @@ def building_summary(parcels, run_number, year,
 def parcel_summary(parcels, buildings, households, jobs,
                    run_number, year,
                    parcels_zoning_calculations,
-                   initial_year, final_year, parcels_geography):
+                   initial_year, final_year, parcels_geography,
+                   scenario, policy):
 
     if year not in [2010, 2015, 2035, 2050]:
         return
@@ -1241,7 +1242,15 @@ def parcel_summary(parcels, buildings, households, jobs,
     df = df.join(df2)
 
     # bringing in zoning modifications growth geography tag
-    join_col = "pba50chcat"
+    if scenario in policy["geographies_db_enable"]:
+        join_col = "pba50chcat"
+    elif scenario in policy["geographies_fb_enable"]:
+        join_col = "fbpchcat"
+    elif scenario in policy["geographies_pba40_enable"]s:
+        join_col = 'zoningmodcat'
+    else:
+        join_col = 'zoninghzcat'
+
     if join_col in parcels_geography.to_frame().columns:
         parcel_gg = parcels_geography.to_frame([
             "parcel_id",

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -966,7 +966,8 @@ def geographic_summary(parcels, households, jobs, buildings, taz_geography,
         [parcels, buildings],
         columns=['pda_pba40', 'pda_pba50', 'superdistrict', 'juris',
                  'building_type', 'zone_id', 'residential_units',
-                 'preserved_units', 'inclusionary_units',
+                 'deed_restricted_units', 'preserved_units',
+                 'inclusionary_units',
                  'building_sqft', 'non_residential_sqft',
                  'juris_trich', 'juris_tra', 'juris_sesit', 'juris_ppa'])
 
@@ -1068,19 +1069,24 @@ def geographic_summary(parcels, households, jobs, buildings, taz_geography,
             summary_table['sq_ft_per_employee'] = \
                 summary_table['non_residential_sqft'] / summary_table['totemp']
 
+            # columns re: affordable housing
+            summary_table['deed_restricted_units'] = buildings_df.\
+                groupby(geography).deed_restricted_units.sum()
+            summary_table['preserved_units'] = buildings_df.\
+                groupby(geography).preserved_units.sum()
+            summary_table['inclusionary_units'] = buildings_df.\
+                groupby(geography).inclusionary_units.sum()
+            summary_table['subsidized_units'] = \
+                summary_table['deed_restricted_units'] - \
+                summary_table['preserved_units'] - \
+                summary_table['inclusionary_units']
+
+            # additional columns from parcel_output
             if parcel_output is not None:
                 parcel_output['subsidized_units'] = \
                     parcel_output.deed_restricted_units - \
                     parcel_output.inclusionary_units
 
-                # columns re: affordable housing
-                summary_table['deed_restricted_units'] = \
-                    parcel_output.groupby(geography).\
-                    deed_restricted_units.sum()
-                summary_table['inclusionary_units'] = \
-                    parcel_output.groupby(geography).inclusionary_units.sum()
-                summary_table['subsidized_units'] = \
-                    parcel_output.groupby(geography).subsidized_units.sum()
                 summary_table['inclusionary_revenue_reduction'] = \
                     parcel_output.groupby(geography).\
                     policy_based_revenue_reduction.sum()
@@ -1092,16 +1098,7 @@ def geographic_summary(parcels, households, jobs, buildings, taz_geography,
                     groupby(geography).max_profit.sum() * -1
                 summary_table['subsidy_per_unit'] = \
                     summary_table.total_subsidy / \
-                    summary_table.subsidized_units
-
-            summary_table['preserved_units'] = buildings_df.\
-            	groupby(geography).preserved_units.sum()
-
-            summary_table['deed_restricted_units_blg'] = buildings_df.\
-                groupby(geography).deed_restricted_units.sum()
-
-            summary_table['inclusionary_units_blg'] = buildings_df.\
-                groupby(geography).inclusionary_units.sum()           
+                    summary_table.subsidized_units      
 
             summary_table = summary_table.sort_index()
 

--- a/configs/policy.yaml
+++ b/configs/policy.yaml
@@ -26,6 +26,8 @@ office_caps_fr2_enable: ["11", "12", "15"]
 inclusionary_fr2_enable: ["11", "12", "15"]
 # scenarios for draft blueprint inclusionary rates
 inclusionary_d_b_enable: ["20", "21", "22", "23"]
+# scenarios for final blueprint inclusionary rates
+inclusionary_fb_enable: ["24"]
 
 # this is added for housing relocation rate function in models.py
 # this is to differentiate futures baseline rates
@@ -1423,6 +1425,213 @@ inclusionary_housing_settings:
       - NAtra3c2HRADRNA
       - NAtra3c2HRANA
       - NAtra3c2NANA
+  "24":
+    - type: fbpchcat
+      description: high setting
+      amount: .2
+      values:
+      - GGtra1HRADISNAin
+      - GGtra1HRANAin
+      - GGtra2aHRADISNAin
+      - GGtra2aHRADISNAinun
+      - GGtra2aHRANAin
+      - GGtra2aHRANAinun
+      - GGtra2bHRADISNAin
+      - GGtra2bHRADISNAinun
+      - GGtra2bHRANAin
+      - GGtra2cHRADISNAin
+      - GGtra2cHRANAin
+      - GGtra3HRADISNAexp0
+      - GGtra3HRADISNAin
+      - GGtra3HRADISNAinun
+      - GGtra3HRADISNAout
+      - GGtra3HRANAin
+      - GGtra3HRANAinun
+      - GGtra3HRANAout
+    - type: fbpchcat
+      description: medium setting
+      amount: .15
+      values:
+      - GGNAHRADISNAexp0
+      - GGNAHRADISNAin
+      - GGNAHRADISNAinun
+      - GGNAHRADISNAout
+      - GGNAHRANAexp0
+      - GGNAHRANAexp1
+      - GGNAHRANAexp1_np
+      - GGNAHRANAin
+      - GGNAHRANAinun
+      - GGNAHRANAout
+      - GGtra1DISNAin
+      - GGtra1DISNAinun
+      - GGtra1DISNAout
+      - GGtra1NANAin
+      - GGtra1NANAinun
+      - GGtra1NANAout
+      - GGtra2aDISNAin
+      - GGtra2aDISNAinun
+      - GGtra2aDISppain
+      - GGtra2aNANAin
+      - GGtra2aNANAinun
+      - GGtra2aNANAout
+      - GGtra2bDISNAin
+      - GGtra2bDISppain
+      - GGtra2bNANAin
+      - GGtra2bNAppain
+      - GGtra2cDISNAin
+      - GGtra2cNANAin
+    - type: fbpchcat
+      description: low setting
+      amount: .1
+      values:
+      - GGNADISNAexp0
+      - GGNADISNAexp2_np
+      - GGNADISNAin
+      - GGNADISNAinun
+      - GGNADISNAout
+      - GGNADISppain
+      - GGNANANAexp0
+      - GGNANANAexp1
+      - GGNANANAexpmax_np
+      - GGNANANAin
+      - GGNANANAinun
+      - GGNANANAout
+      - GGNANAppain
+      - GGtra3DISNAexp0
+      - GGtra3DISNAexp1
+      - GGtra3DISNAin
+      - GGtra3DISNAinun
+      - GGtra3DISNAout
+      - GGtra3DISppain
+      - GGtra3NANAexp1
+      - GGtra3NANAexp3_au
+      - GGtra3NANAin
+      - GGtra3NANAinun
+      - GGtra3NANAout
+      - GGtra3NAppain
+      - NANADISNAexp0
+      - NANADISNAexp0_np
+      - NANADISNAexp1
+      - NANADISNAexp1_np
+      - NANADISNAexp2_np
+      - NANADISNAexp3_au
+      - NANADISNAexpmax
+      - NANADISNAexpmax_np
+      - NANADISNAin
+      - NANADISNAinun
+      - NANADISNAout
+      - NANADISNAubz
+      - NANADISNAubz_np
+      - NANADISppaexp0
+      - NANADISppaexp1
+      - NANADISppaexp1_np
+      - NANADISppaexp2_np
+      - NANADISppaexp3_au
+      - NANADISppain
+      - NANADISppainun
+      - NANADISppaout
+      - NANAHRADISNAexp0
+      - NANAHRADISNAexp0_np
+      - NANAHRADISNAexp1
+      - NANAHRADISNAexp1_np
+      - NANAHRADISNAexp2_np
+      - NANAHRADISNAexp3_au
+      - NANAHRADISNAexpmax
+      - NANAHRADISNAexpmax_np
+      - NANAHRADISNAin
+      - NANAHRADISNAinun
+      - NANAHRADISNAout
+      - NANAHRADISNAubz
+      - NANAHRADISNAubz_np
+      - NANAHRADISppain
+      - NANAHRANAexp0
+      - NANAHRANAexp0_np
+      - NANAHRANAexp1
+      - NANAHRANAexp1_np
+      - NANAHRANAexp2_np
+      - NANAHRANAexp3_au
+      - NANAHRANAexpmax_np
+      - NANAHRANAin
+      - NANAHRANAinun
+      - NANAHRANAout
+      - NANAHRANAubz
+      - NANANANAexp0
+      - NANANANAexp0_np
+      - NANANANAexp1
+      - NANANANAexp1_np
+      - NANANANAexp2_np
+      - NANANANAexp3_au
+      - NANANANAexpmax
+      - NANANANAexpmax_np
+      - NANANANAin
+      - NANANANAinun
+      - NANANANAout
+      - NANANANAubz
+      - NANANAppaexp0
+      - NANANAppaexp1
+      - NANANAppaexp1_np
+      - NANANAppain
+      - NANANAppainun
+      - NANANAppaout
+      - NAtra1DISNAin
+      - NAtra1HRADISNAin
+      - NAtra1HRANAin
+      - NAtra1NANAin
+      - NAtra2aDISNAin
+      - NAtra2aDISNAinun
+      - NAtra2aDISNAout
+      - NAtra2aHRADISNAin
+      - NAtra2aHRANAin
+      - NAtra2aHRANAinun
+      - NAtra2aNANAin
+      - NAtra2aNANAinun
+      - NAtra2aNANAout
+      - NAtra2bDISNAin
+      - NAtra2bDISNAout
+      - NAtra2bHRADISNAin
+      - NAtra2bHRANAin
+      - NAtra2bNANAin
+      - NAtra2bNANAinun
+      - NAtra2bNANAout
+      - NAtra2cDISNAin
+      - NAtra2cDISppain
+      - NAtra2cHRADISNAin
+      - NAtra2cHRANAin
+      - NAtra2cNANAin
+      - NAtra2cNANAout
+      - NAtra2cNAppain
+      - NAtra3DISNAexp0
+      - NAtra3DISNAexp1
+      - NAtra3DISNAexp1_np
+      - NAtra3DISNAexp3_au
+      - NAtra3DISNAin
+      - NAtra3DISNAinun
+      - NAtra3DISNAout
+      - NAtra3DISppaexp1
+      - NAtra3DISppain
+      - NAtra3DISppainun
+      - NAtra3DISppaout
+      - NAtra3HRADISNAexp0
+      - NAtra3HRADISNAexp1
+      - NAtra3HRADISNAexp1_np
+      - NAtra3HRADISNAin
+      - NAtra3HRADISNAinun
+      - NAtra3HRADISNAout
+      - NAtra3HRANAexp0
+      - NAtra3HRANAexp1_np
+      - NAtra3HRANAin
+      - NAtra3HRANAinun
+      - NAtra3HRANAout
+      - NAtra3HRANAubz
+      - NAtra3NANAexp0
+      - NAtra3NANAexp1
+      - NAtra3NANAexp1_np
+      - NAtra3NANAexp3_au
+      - NAtra3NANAin
+      - NAtra3NANAinun
+      - NAtra3NANAout
+      - NAtra3NAppain
+      - NAtra3NAppainun
 
 # these are the settings for various policies that are in play
 acct_settings:


### PR DESCRIPTION
Changes:

- s24 strategy setting in policy.yaml

- added an `inclusionary_units` column to the `buildings` table, along with adjustments to the [`overshoot` calculation in `residential_developer()` model](https://github.com/BayAreaMetro/bayarea_urbansim/commit/d06c37a455c76048084ab5ccab46596e3b9d007e#diff-1708297b6f4a38f9917cec4dd5a40299R676) and [`developer_reprocess()` model](https://github.com/BayAreaMetro/bayarea_urbansim/commit/1eab4251f06865a4d49f2a3dbff91cfad68b1255#diff-1708297b6f4a38f9917cec4dd5a40299).

- started to use `buildings` instead of `parcel_output` (which comes from `new_buildings`) in affordable units' geographic summaries. This is because `new_buildings` doesn't adjust for overshoot, so it inflates total residential_units count and inclusionary_units count a little bit (less than 1% though)

- given that geographic summaries still uses other columns of `parcel_output` for certain calculations (e.g. "inclusionary_revenue_reduction", "subsidy_per_unit"), applies [similar overshoot adjustments](https://github.com/BayAreaMetro/bayarea_urbansim/compare/develop...BayAreaMetro:fb_inclusionary_v2#diff-1708297b6f4a38f9917cec4dd5a40299R680) to `new_buildings`.

Test run (run20 on desktop) created 124,678 inclusionary units, 40% more than in the September release run (88,745 units), which reflects baseline/default setting.