### PR TITLE
add slr to s24

### DIFF
--- a/configs/hazards.yaml
+++ b/configs/hazards.yaml
@@ -1,18 +1,18 @@
 # scenarios for hazards models
 slr_scenarios:
-      enable_in: ["1", "2", "5", "11", "12", "15", "20", "21", "22", "23"]
+      enable_in: ["1", "2", "5", "11", "12", "15", "20", "21", "22", "23", "24"]
       horizon_scenarios: ["1", "2", "5", "11", "12", "15"]
-      draft_blueprint_scenarios: ["20", "21", "22", "23"]
+      draft_blueprint_scenarios: ["20", "21", "22", "23", "24"] # final blueprint is the same
       # progression
       rtff_prog: ["2", "7", "12"]
       cag_prog: ["1", "6", "11"]
       bttf_prog: ["5", "10", "15"]
-      d_b_prog: ["20", "21", "22", "23"]
+      d_b_prog: ["20", "21", "22", "23", "24"] # final blueprint is the same
       # inundation
       mitigation_full: ["11", "15"] # futures round 2
       mitigation_partial: ["12"] # futures round 2
       d_bb_mitigation: ["21"]
-      d_bp_mitigation: ["22", "23"]
+      d_bp_mitigation: ["22", "23", "24"] # final blueprint is the same
 eq_scenarios:
       enable_in: ["1", "2", "5", "11", "12", "15"]
       # scenarios for futures rounds 2 mitigation


### PR DESCRIPTION
Applied the same SLR conditions and mitigation to s24 as was done in s23. Checked configuration.log to confirm that the same policy setting were applied. 

Checked the hazards_slr_[year].log files to confirm that the affected parcel count was the same as s23. 