### PR TITLE
FB office lump sum acct v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,3 @@ data/2020_06_15_zoning_parcels_hybrid_pba50.csv
 data/2020_07_10_parcels_geography.csv
 .DS_Store
 data/2020_09_21_parcels_geography.csv
-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ data/2020_06_15_zoning_parcels_hybrid_pba50.csv
 data/2020_07_10_parcels_geography.csv
 .DS_Store
 data/2020_09_21_parcels_geography.csv
+debug.log

--- a/baus.py
+++ b/baus.py
@@ -165,9 +165,13 @@ def get_simulation_models(SCENARIO):
 
         # preserve some units
         "preserve_affordable",
-        # run the subsidized acct system
+        # run the subsidized residential acct system
         "lump_sum_accounts",
         "subsidized_residential_developer_lump_sum_accts",
+
+        # run the subsidized office acct system
+        "office_lump_sum_accounts",
+        "subsidized_office_developer_lump_sum_accts",
 
         "alt_feasibility",
 
@@ -249,7 +253,7 @@ def get_simulation_models(SCENARIO):
     if SCENARIO in vmt_settings["com_for_com_scenarios"] and \
             SCENARIO not in vmt_settings["db_geography_scenarios"]:
         models.insert(models.index("office_developer"),
-                      "subsidized_office_developer")
+                      "subsidized_office_developer_vmt")
 
     if SCENARIO in vmt_settings["com_for_res_scenarios"] or \
             SCENARIO in vmt_settings["res_for_res_scenarios"]:

--- a/baus/subsidies.py
+++ b/baus/subsidies.py
@@ -46,6 +46,10 @@ def coffer(policy, scenario):
             policy["acct_settings"]["lump_sum_accounts"].items():
         d[acct["name"]] = accounts.Account(acct["name"])
 
+    for key, acct in \
+            policy["acct_settings"]["office_lump_sum_accounts"].items():
+        d[acct["name"]] = accounts.Account(acct["name"])    
+
     if scenario in (policy["acct_settings"]["jobs_housing_fee_settings"]
                     ["jobs_housing_com_for_res_scenarios"]):
         for key, acct in \
@@ -191,6 +195,28 @@ def lump_sum_accounts(policy, year, buildings, coffer,
         coffer[acct["name"]].add_transaction(amt, subaccount=1,
                                              metadata=metadata)
 
+@orca.step()
+def office_lump_sum_accounts(policy, year, buildings, coffer,
+                             summary, years_per_iter, scenario):
+
+    s = policy["acct_settings"]["office_lump_sum_accounts"]
+
+    for key, acct in s.items():
+        if scenario not in acct["enable_in_scenarios"]:
+            continue
+
+        amt = float(acct["total_amount"])
+
+        amt *= years_per_iter
+
+        metadata = {
+            "description": "%s subsidies" % acct["name"],
+            "year": year
+        }
+        # the subaccount is meaningless here (it's a regional account) -
+        # but the subaccount number is referred to below
+        coffer[acct["name"]].add_transaction(amt, subaccount="regional",
+                                             metadata=metadata)
 
 # this will compute the reduction in revenue from a project due to
 # inclustionary housing - the calculation will be described in thorough

--- a/baus/subsidies.py
+++ b/baus/subsidies.py
@@ -654,14 +654,10 @@ def subsidized_office_developer(feasibility, coffer, formula, year,
 
     # get the office feasibility frame and sort by profit per sqft
     
-    print('size of feasibility 1: {}'.format(feasibility.shape))
-    print('size of feasibility 2: {}'.format(feasibility.shape))
     feasibility = feasibility.loc[:, "office"]
-    print('head of feasibility: {}'.format(feasibility.head()))
-    print('columns of feasibility: \n{}'.format(list(feasibility)))
 
     feasibility = feasibility.dropna(subset=["max_profit"])
-    print('size of feasibility 3: {}'.format(feasibility.shape))
+
     # add necessary columns for filters
     policy = orca.get_injectable("policy")
     scenario = orca.get_injectable("scenario")
@@ -673,9 +669,7 @@ def subsidized_office_developer(feasibility, coffer, formula, year,
         feasibility["pda_id"] = feasibility.pda_pba50
 
     # filter to receiving zone
-    print('size of feasibility 4: {}'.format(feasibility.shape))
     feasibility = feasibility.query(formula)
-    print('size of feasibility 5: {}'.format(feasibility.shape))
 
     feasibility["non_residential_sqft"] = \
         feasibility.non_residential_sqft.astype("int")
@@ -721,6 +715,9 @@ def subsidized_office_developer(feasibility, coffer, formula, year,
             "description": "Developing subsidized office building",
             "year": year,
             "non_residential_sqft": d["non_residential_sqft"],
+            "juris": d["juris"],
+            "tra_id": d["tra_id"],
+            "parcel_id": d["parcel_id"],
             "index": dev_id
         }
 
@@ -1187,6 +1184,8 @@ def subsidized_office_developer_vmt(
         else:
             formula = vmt_acct_settings["receiving_buildings_filter"]
 
+        print('office receiving_buildings_filter: {}'.format(formula))
+
         subsidized_office_developer(feasibility,
                                     coffer,
                                     formula,
@@ -1218,10 +1217,9 @@ def subsidized_office_developer_lump_sum_accts(
 
         orca.eval_step("alt_feasibility")
         feasibility = orca.get_table("feasibility").to_frame()
-        print('head of feasibility: {}'.format(feasibility.head()))
-        print('columns of feasibility: \n{}'.format(list(feasibility)))
 
         formula = acct["receiving_buildings_filter"]
+        print('office receiving_buildings_filter: {}'.format(formula))
 
         subsidized_office_developer(feasibility,
                                     coffer,

--- a/baus/subsidies.py
+++ b/baus/subsidies.py
@@ -1170,7 +1170,7 @@ def subsidized_office_developer_vmt(
 
     vmt_acct_settings = policy["acct_settings"]["vmt_settings"]
 
-    if scenario in policy_setting["com_for_com_scenarios"]:
+    if scenario in vmt_acct_settings["com_for_com_scenarios"]:
 
         print("Running subsidized office developer for acct: VMT com_for_com")
 

--- a/baus/subsidies.py
+++ b/baus/subsidies.py
@@ -643,30 +643,39 @@ def calculate_jobs_housing_fees(policy, year, buildings,
                                                      metadata=metadata)
 
 
-@orca.step()
-def subsidized_office_developer(feasibility, coffer, acct_settings, year,
-                                add_extra_columns_func, buildings, summary):
+#@orca.step()
+def subsidized_office_developer(feasibility, coffer, formula, year,
+                                add_extra_columns_func, buildings,
+                                summary, coffer_acct_name):
 
     # get the total subsidy for subsidizing office
-    total_subsidy = coffer["vmt_com_acct"].\
+    total_subsidy = coffer[coffer_acct_name].\
         total_transactions_by_subacct("regional")
 
     # get the office feasibility frame and sort by profit per sqft
-    feasibility = feasibility.to_frame().loc[:, "office"]
+    
+    print('size of feasibility 1: {}'.format(feasibility.shape))
+    print('size of feasibility 2: {}'.format(feasibility.shape))
+    feasibility = feasibility.loc[:, "office"]
+    print('head of feasibility: {}'.format(feasibility.head()))
+    print('columns of feasibility: \n{}'.format(list(feasibility)))
+
     feasibility = feasibility.dropna(subset=["max_profit"])
+    print('size of feasibility 3: {}'.format(feasibility.shape))
+    # add necessary columns for filters
+    policy = orca.get_injectable("policy")
+    scenario = orca.get_injectable("scenario")
 
-    feasibility["pda_id"] = feasibility.pda
-
-    if "alternate_geography_scenarios" in acct_settings["vmt_settings"] \
-            and orca.get_injectable("scenario") in \
-            acct_settings["vmt_settings"]["alternate_geography_scenarios"]:
-        formula = acct_settings["vmt_settings"]["alternate_buildings_filter"]
-    else:
-        formula = acct_settings["vmt_settings"]["receiving_buildings_filter"]
+    if scenario in policy["geographies_pba40_enable"]:
+        feasibility["pda_id"] = feasibility.pda_pba40
+    elif scenario in policy["geographies_db_enable"] or \
+        scenario in policy["geographies_fb_enable"]:
+        feasibility["pda_id"] = feasibility.pda_pba50
 
     # filter to receiving zone
-    feasibility = feasibility.\
-        query(formula)
+    print('size of feasibility 4: {}'.format(feasibility.shape))
+    feasibility = feasibility.query(formula)
+    print('size of feasibility 5: {}'.format(feasibility.shape))
 
     feasibility["non_residential_sqft"] = \
         feasibility.non_residential_sqft.astype("int")
@@ -715,8 +724,8 @@ def subsidized_office_developer(feasibility, coffer, acct_settings, year,
             "index": dev_id
         }
 
-        coffer["vmt_com_acct"].add_transaction(-1*amt, subaccount="regional",
-                                               metadata=metadata)
+        coffer[coffer_acct_name].add_transaction(-1*amt, subaccount="regional",
+                                                 metadata=metadata)
 
         total_subsidy -= amt
 
@@ -731,6 +740,7 @@ def subsidized_office_developer(feasibility, coffer, acct_settings, year,
 
     print("Building {:,} subsidized office sqft in {:,} projects".format(
         devs.non_residential_sqft.sum(), len(devs)))
+    print("%.0f subsidy left" %total_subsidy)
 
     devs["form"] = "office"
     devs = add_extra_columns_func(devs)
@@ -1149,6 +1159,78 @@ def subsidized_residential_developer_lump_sum_accts(
                                  create_deed_restricted=acct[
                                     "subsidize_affordable"],
                                  policy_name=acct["name"])
+
+        buildings = orca.get_table("buildings")
+
+        # set to an empty dataframe to save memory
+        orca.add_table("feasibility", pd.DataFrame())
+
+
+@orca.step()
+def subsidized_office_developer_vmt(
+    parcels, settings, scenario, coffer, buildings, year, policy,
+    add_extra_columns_func, summary):
+
+    vmt_acct_settings = policy["acct_settings"]["vmt_settings"]
+
+    if scenario in policy_setting["com_for_com_scenarios"]:
+
+        print("Running subsidized office developer for acct: VMT com_for_com")
+
+        orca.eval_step("alt_feasibility")
+        feasibility = orca.get_table("feasibility").to_frame()
+
+        if "alternate_geography_scenarios" in vmt_acct_settings \
+            and orca.get_injectable("scenario") in \
+            vmt_acct_settings["alternate_geography_scenarios"]:
+            formula = vmt_acct_settings["alternate_buildings_filter"]
+        else:
+            formula = vmt_acct_settings["receiving_buildings_filter"]
+
+        subsidized_office_developer(feasibility,
+                                    coffer,
+                                    formula,
+                                    year,
+                                    add_extra_columns_func,
+                                    buildings,
+                                    summary, 
+                                    coffer_acct_name="vmt_com_acct")
+
+        buildings = orca.get_table("buildings")
+
+        # set to an empty dataframe to save memory
+        # this is ok because baus.py will run alt_reasibility in the next step
+        orca.add_table("feasibility", pd.DataFrame())
+
+
+@orca.step()
+def subsidized_office_developer_lump_sum_accts(
+    parcels, settings, scenario, coffer, buildings, year, policy,
+    add_extra_columns_func, summary):
+
+    for key, acct in policy["acct_settings"]["office_lump_sum_accounts"].items():
+
+        # quick return in order to save performance time
+        if scenario not in acct["enable_in_scenarios"]:
+            continue
+
+        print("Running the subsidized office developer for acct: %s" % acct["name"])
+
+        orca.eval_step("alt_feasibility")
+        feasibility = orca.get_table("feasibility").to_frame()
+        print('head of feasibility: {}'.format(feasibility.head()))
+        print('columns of feasibility: \n{}'.format(list(feasibility)))
+
+        formula = acct["receiving_buildings_filter"]
+
+        subsidized_office_developer(feasibility,
+                                    coffer,
+                                    formula,
+                                    year,
+                                    add_extra_columns_func,
+                                    buildings,
+                                    summary, 
+                                    coffer_acct_name=acct["name"])
 
         buildings = orca.get_table("buildings")
 

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -378,6 +378,21 @@ def config(policy, inputs, run_number, scenario, parcels,
                 regional_units += units*8
     write("Total unit target for preserving units is %d" % regional_units)
 
+    # office subsidy bonds
+    counter = 0
+    acct_list = []
+    regional_funding = 0
+    policy_loc = policy["acct_settings"]["office_lump_sum_accounts"].items()
+    for key, acct in policy_loc:
+        if scenario in acct["enable_in_scenarios"]:
+            counter += 1
+            acct_list.append(acct["name"].split(' Office')[0])
+            amount = float(acct["total_amount"])
+            regional_funding += amount*5*7
+    write("Office subsidy bonds are activated for %d jurisdictions:" % counter)
+    write(str(acct_list))
+    write("Total funding is $%d" % regional_funding)
+
     f.close()
 
 

--- a/configs/policy.yaml
+++ b/configs/policy.yaml
@@ -1641,6 +1641,7 @@ inclusionary_housing_settings:
 acct_settings:
   disable: False
 
+  # residential lump_sum_accounts
   lump_sum_accounts:
 
     # obag, where to spend the funds, how much to add, and which scenarios to
@@ -1822,6 +1823,99 @@ acct_settings:
       receiving_buildings_filter: pda_id > ''
       subsidize_affordable: True
       enable_in_scenarios: []
+
+  # office lump_sum_accounts
+  office_lump_sum_accounts:
+    dublin_office_bond_settings:
+      name: "Dublin Office Subsidy Bond"
+      sending_buildings_subaccount_def: regional
+      total_amount: 863636364
+      receiving_buildings_filter: juris == 'Dublin'
+      enable_in_scenarios: ["24"]
+    fremont_office_bond_settings:
+      name: "Fremont Office Subsidy Bond"
+      sending_buildings_subaccount_def: regional
+      total_amount: 863636364
+      receiving_buildings_filter: juris == 'Fremont'
+      enable_in_scenarios: ["24"]
+    oakland_office_bond_settings:
+      name: "Oakland Office Subsidy Bond"
+      sending_buildings_subaccount_def: regional
+      total_amount: 863636364
+      receiving_buildings_filter: juris == 'Oakland'
+      enable_in_scenarios: ["24"]
+    san_leandro_office_bond_settings:
+      name: "San Leandro Office Subsidy Bond"
+      sending_buildings_subaccount_def: regional
+      total_amount: 863636364
+      receiving_buildings_filter: juris == 'San Leandro'
+      enable_in_scenarios: ["24"]
+    union_city_office_bond_settings:
+      name: "Union City Office Subsidy Bond"
+      sending_buildings_subaccount_def: regional
+      total_amount: 863636364
+      receiving_buildings_filter: juris == 'Union City'
+      enable_in_scenarios: ["24"]
+    antioch_office_bond_settings:
+      name: "Antioch Office Subsidy Bond"
+      sending_buildings_subaccount_def: regional
+      total_amount: 863636364
+      receiving_buildings_filter: juris == 'Antioch'
+      enable_in_scenarios: ["24"]
+    concord_office_bond_settings:
+      name: "Concord Office Subsidy Bond"
+      sending_buildings_subaccount_def: regional
+      total_amount: 863636364
+      receiving_buildings_filter: juris == 'Concord'
+      enable_in_scenarios: ["24"]
+    el_cerrito_office_bond_settings:
+      name: "El Cerrito Office Subsidy Bond"
+      sending_buildings_subaccount_def: regional
+      total_amount: 863636364
+      receiving_buildings_filter: juris == 'El Cerrito'
+      enable_in_scenarios: ["24"]
+    lafayette_office_bond_settings:
+      name: "Lafayette Office Subsidy Bond"
+      sending_buildings_subaccount_def: regional
+      total_amount: 863636364
+      receiving_buildings_filter: juris == 'Lafayette'
+      enable_in_scenarios: ["24"]
+    pittsburg_office_bond_settings:
+      name: "Pittsburg Office Subsidy Bond"
+      sending_buildings_subaccount_def: regional
+      total_amount: 863636364
+      receiving_buildings_filter: juris == 'Pittsburg'
+      enable_in_scenarios: ["24"]
+    richmond_office_bond_settings:
+      name: "Richmond Office Subsidy Bond"
+      sending_buildings_subaccount_def: regional
+      total_amount: 863636364
+      receiving_buildings_filter: juris == 'Richmond'
+      enable_in_scenarios: ["24"]
+    san_rafael_office_bond_settings:
+      name: "San Rafael Office Subsidy Bond"
+      sending_buildings_subaccount_def: regional
+      total_amount: 125000000
+      receiving_buildings_filter: juris == 'San Rafael'
+      enable_in_scenarios: ["24"]
+    fairfield_office_bond_settings:
+      name: "Fairfield Office Subsidy Bond"
+      sending_buildings_subaccount_def: regional
+      total_amount: 125000000
+      receiving_buildings_filter: juris == 'Fairfield'
+      enable_in_scenarios: ["24"]
+    vacaville_office_bond_settings:
+      name: "Vacaville Office Subsidy Bond"
+      sending_buildings_subaccount_def: regional
+      total_amount: 125000000
+      receiving_buildings_filter: juris == 'Vacaville'
+      enable_in_scenarios: ["24"]
+    santa_rosa_office_bond_settings:
+      name: "Santa Rosa Office Subsidy Bond"
+      sending_buildings_subaccount_def: regional
+      total_amount: 125000000
+      receiving_buildings_filter: juris == 'Santa Rosa'
+      enable_in_scenarios: ["24"]   
 
   profitability_adjustment_policies:
 

--- a/configs/policy.yaml
+++ b/configs/policy.yaml
@@ -1829,91 +1829,91 @@ acct_settings:
     dublin_office_bond_settings:
       name: "Dublin Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
-      total_amount: 863636364
+      total_amount: 24675325
       receiving_buildings_filter: juris == 'Dublin'
       enable_in_scenarios: ["24"]
     fremont_office_bond_settings:
       name: "Fremont Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
-      total_amount: 863636364
+      total_amount: 24675325
       receiving_buildings_filter: juris == 'Fremont'
       enable_in_scenarios: ["24"]
     oakland_office_bond_settings:
       name: "Oakland Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
-      total_amount: 863636364
+      total_amount: 24675325
       receiving_buildings_filter: juris == 'Oakland'
       enable_in_scenarios: ["24"]
     san_leandro_office_bond_settings:
       name: "San Leandro Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
-      total_amount: 863636364
+      total_amount: 24675325
       receiving_buildings_filter: juris == 'San Leandro'
       enable_in_scenarios: ["24"]
     union_city_office_bond_settings:
       name: "Union City Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
-      total_amount: 863636364
+      total_amount: 24675325
       receiving_buildings_filter: juris == 'Union City'
       enable_in_scenarios: ["24"]
     antioch_office_bond_settings:
       name: "Antioch Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
-      total_amount: 863636364
+      total_amount: 24675325
       receiving_buildings_filter: juris == 'Antioch'
       enable_in_scenarios: ["24"]
     concord_office_bond_settings:
       name: "Concord Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
-      total_amount: 863636364
+      total_amount: 24675325
       receiving_buildings_filter: juris == 'Concord'
       enable_in_scenarios: ["24"]
     el_cerrito_office_bond_settings:
       name: "El Cerrito Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
-      total_amount: 863636364
+      total_amount: 24675325
       receiving_buildings_filter: juris == 'El Cerrito'
       enable_in_scenarios: ["24"]
     lafayette_office_bond_settings:
       name: "Lafayette Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
-      total_amount: 863636364
+      total_amount: 24675325
       receiving_buildings_filter: juris == 'Lafayette'
       enable_in_scenarios: ["24"]
     pittsburg_office_bond_settings:
       name: "Pittsburg Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
-      total_amount: 863636364
+      total_amount: 24675325
       receiving_buildings_filter: juris == 'Pittsburg'
       enable_in_scenarios: ["24"]
     richmond_office_bond_settings:
       name: "Richmond Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
-      total_amount: 863636364
+      total_amount: 24675325
       receiving_buildings_filter: juris == 'Richmond'
       enable_in_scenarios: ["24"]
     san_rafael_office_bond_settings:
       name: "San Rafael Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
-      total_amount: 125000000
+      total_amount: 3571429
       receiving_buildings_filter: juris == 'San Rafael'
       enable_in_scenarios: ["24"]
     fairfield_office_bond_settings:
       name: "Fairfield Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
-      total_amount: 125000000
+      total_amount: 3571429
       receiving_buildings_filter: juris == 'Fairfield'
       enable_in_scenarios: ["24"]
     vacaville_office_bond_settings:
       name: "Vacaville Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
-      total_amount: 125000000
+      total_amount: 3571429
       receiving_buildings_filter: juris == 'Vacaville'
       enable_in_scenarios: ["24"]
     santa_rosa_office_bond_settings:
       name: "Santa Rosa Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
-      total_amount: 125000000
+      total_amount: 3571429
       receiving_buildings_filter: juris == 'Santa Rosa'
       enable_in_scenarios: ["24"]   
 

--- a/configs/policy.yaml
+++ b/configs/policy.yaml
@@ -1830,91 +1830,155 @@ acct_settings:
       name: "Dublin Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
       total_amount: 24675325
-      receiving_buildings_filter: juris == 'Dublin'
+      receiving_buildings_filter: juris == 'Dublin' and (
+                                    tra_id == 'tra1' or
+                                    tra_id == 'tra2a' or
+                                    tra_id == 'tra2b' or
+                                    tra_id == 'tra2c')
       enable_in_scenarios: ["24"]
     fremont_office_bond_settings:
       name: "Fremont Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
       total_amount: 24675325
-      receiving_buildings_filter: juris == 'Fremont'
+      receiving_buildings_filter: juris == 'Fremont' and (
+                                    tra_id == 'tra1' or
+                                    tra_id == 'tra2a' or
+                                    tra_id == 'tra2b' or
+                                    tra_id == 'tra2c')
       enable_in_scenarios: ["24"]
     oakland_office_bond_settings:
       name: "Oakland Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
       total_amount: 24675325
-      receiving_buildings_filter: juris == 'Oakland'
+      receiving_buildings_filter: juris == 'Oakland' and (
+                                    tra_id == 'tra1' or
+                                    tra_id == 'tra2a' or
+                                    tra_id == 'tra2b' or
+                                    tra_id == 'tra2c')
       enable_in_scenarios: ["24"]
     san_leandro_office_bond_settings:
       name: "San Leandro Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
       total_amount: 24675325
-      receiving_buildings_filter: juris == 'San Leandro'
+      receiving_buildings_filter: juris == 'San Leandro' and (
+                                    tra_id == 'tra1' or
+                                    tra_id == 'tra2a' or
+                                    tra_id == 'tra2b' or
+                                    tra_id == 'tra2c')
       enable_in_scenarios: ["24"]
     union_city_office_bond_settings:
       name: "Union City Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
       total_amount: 24675325
-      receiving_buildings_filter: juris == 'Union City'
+      receiving_buildings_filter: juris == 'Union City' and (
+                                    tra_id == 'tra1' or
+                                    tra_id == 'tra2a' or 
+                                    tra_id == 'tra2b' or
+                                    tra_id == 'tra2c')
       enable_in_scenarios: ["24"]
     antioch_office_bond_settings:
       name: "Antioch Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
       total_amount: 24675325
-      receiving_buildings_filter: juris == 'Antioch'
+      receiving_buildings_filter: juris == 'Antioch' and (
+                                    tra_id == 'tra1' or 
+                                    tra_id == 'tra2a' or 
+                                    tra_id == 'tra2b' or
+                                    tra_id == 'tra2c')
       enable_in_scenarios: ["24"]
     concord_office_bond_settings:
       name: "Concord Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
       total_amount: 24675325
-      receiving_buildings_filter: juris == 'Concord'
+      receiving_buildings_filter: juris == 'Concord' and (
+                                    tra_id == 'tra1' or 
+                                    tra_id == 'tra2a' or 
+                                    tra_id == 'tra2b' or
+                                    tra_id == 'tra2c')
       enable_in_scenarios: ["24"]
     el_cerrito_office_bond_settings:
       name: "El Cerrito Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
       total_amount: 24675325
-      receiving_buildings_filter: juris == 'El Cerrito'
+      receiving_buildings_filter: juris == 'El Cerrito' and (
+                                    tra_id == 'tra1' or
+                                    tra_id == 'tra2a' or
+                                    tra_id == 'tra2b' or
+                                    tra_id == 'tra2c')
       enable_in_scenarios: ["24"]
     lafayette_office_bond_settings:
       name: "Lafayette Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
       total_amount: 24675325
-      receiving_buildings_filter: juris == 'Lafayette'
+      receiving_buildings_filter: juris == 'Lafayette' and (
+                                    tra_id == 'tra1' or
+                                    tra_id == 'tra2a' or
+                                    tra_id == 'tra2b' or
+                                    tra_id == 'tra2c')
       enable_in_scenarios: ["24"]
     pittsburg_office_bond_settings:
       name: "Pittsburg Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
       total_amount: 24675325
-      receiving_buildings_filter: juris == 'Pittsburg'
+      receiving_buildings_filter: juris == 'Pittsburg' and (
+                                    tra_id == 'tra1' or
+                                    tra_id == 'tra2a' or
+                                    tra_id == 'tra2b' or
+                                    tra_id == 'tra2c')
       enable_in_scenarios: ["24"]
     richmond_office_bond_settings:
       name: "Richmond Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
       total_amount: 24675325
-      receiving_buildings_filter: juris == 'Richmond'
+      receiving_buildings_filter: juris == 'Richmond' and (
+                                    tra_id == 'tra1' or
+                                    tra_id == 'tra2a' or
+                                    tra_id == 'tra2b' or
+                                    tra_id == 'tra2c')
       enable_in_scenarios: ["24"]
     san_rafael_office_bond_settings:
       name: "San Rafael Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
       total_amount: 3571429
-      receiving_buildings_filter: juris == 'San Rafael'
+      receiving_buildings_filter: juris == 'San Rafael' and (
+                                    tra_id == 'tra1' or
+                                    tra_id == 'tra2a' or 
+                                    tra_id == 'tra2b' or
+                                    tra_id == 'tra2c' or
+                                    tra_id == 'tra3')
       enable_in_scenarios: ["24"]
     fairfield_office_bond_settings:
       name: "Fairfield Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
       total_amount: 3571429
-      receiving_buildings_filter: juris == 'Fairfield'
+      receiving_buildings_filter: juris == 'Fairfield' and (
+                                    tra_id == 'tra1' or
+                                    tra_id == 'tra2a' or 
+                                    tra_id == 'tra2b' or
+                                    tra_id == 'tra2c' or
+                                    tra_id == 'tra3')
       enable_in_scenarios: ["24"]
     vacaville_office_bond_settings:
       name: "Vacaville Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
       total_amount: 3571429
-      receiving_buildings_filter: juris == 'Vacaville'
+      receiving_buildings_filter: juris == 'Vacaville' and (
+                                    tra_id == 'tra1' or
+                                    tra_id == 'tra2a' or 
+                                    tra_id == 'tra2b' or
+                                    tra_id == 'tra2c' or
+                                    tra_id == 'tra3')
       enable_in_scenarios: ["24"]
     santa_rosa_office_bond_settings:
       name: "Santa Rosa Office Subsidy Bond"
       sending_buildings_subaccount_def: regional
       total_amount: 3571429
-      receiving_buildings_filter: juris == 'Santa Rosa'
+      receiving_buildings_filter: juris == 'Santa Rosa' and (
+                                    tra_id == 'tra1' or
+                                    tra_id == 'tra2a' or 
+                                    tra_id == 'tra2b' or
+                                    tra_id == 'tra2c' or
+                                    tra_id == 'tra3')
       enable_in_scenarios: ["24"]   
 
   profitability_adjustment_policies:


### PR DESCRIPTION
Changes:

1. revised the previous `subsidized_office_developer()` orca step which only applies to the VMT com_to_com strategy to a generic  `subsidized_office_developer()` function
2. coded Final Blueprint office subsidy strategy by creating office lump-sum accounts
3. created `subsidized_office_developer_lump_sum_accts()` orca step and `subsidized_office_developer_vmt()` orca step
4. created a [stand-alone script](https://github.com/BayAreaMetro/petrale/blob/master/scripts/office_lump_sum_summary.ipynb) to summarize office lump-sum acct output. The output has the same format as the residential lump-sum acct.

Note: 

1. The `non_residential_sqft` in the acctlog represents the total sqft of subsidized office buildings, rather than the 'subsidized_sqft'.
2. The sum of `non_residential_sqft` in the acctlog represents all buildings ever subsidized by this strategy, including those that were redeveloped, e.g. some subsidized office buildings built in 2015 were redeveloped in 2040. These buildings are reflected in the `dropped_buildings` output table.