### PR TITLE
Fix taz areatype bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ data/2020_10_27_parcels_geography.csv
 data/2020_11_05_zoning_lookup_hybrid_pba50.csv
 data/2020_11_05_zoning_parcels_hybrid_pba50.csv
 data/2020_11_10_parcels_geography.csv
+data/2020_10_20_zoning_lookup_hybrid_pba50.csv
+data/2020_10_20_zoning_parcels_hybrid_pba50.csv
+data/2020_10_27_zoning_parcels_hybrid_pba50.csv
+data/2020_10_27_zoning_lookup_hybrid_pba50.csv

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -1524,14 +1524,6 @@ def travel_model_output(parcels, households, jobs, buildings,
     taz_df = add_population(taz_df, year, rc)
     taz_df.totpop = taz_df.hhpop + taz_df.gqpop
     taz_df = add_employment(taz_df, year, rc)
-    taz_df_pop_na = taz_df.loc[taz_df.totpop.isnull()]
-    print(taz_df_pop_na)
-    taz_df_emp_na = taz_df.loc[taz_df.totemp.isnull()]
-    print(taz_df_emp_na)
-    taz_df_acre_na = taz_df.loc[taz_df.totacre.isnull()]
-    print(taz_df_acre_na)
-    taz_df_zero_emp = taz_df.loc[taz_df.totemp == 0]
-    print(taz_df_zero_emp)
     taz_df["density_pop"] = taz_df.totpop / taz_df.totacre
     taz_df["density_pop"] = taz_df["density_pop"].fillna(0)
     taz_df["density_emp"] = (2.5 * taz_df.totemp) / taz_df.totacre

--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -1486,13 +1486,6 @@ def travel_model_output(parcels, households, jobs, buildings,
     taz_df["totacre"] = zone_forecast_inputs.totacre_abag
     # total population = group quarters plus households population
     taz_df["totpop"] = (taz_df.hhpop + taz_df.gqpop).fillna(0)
-    taz_df["density"] = \
-        (taz_df.totpop + (2.5 * taz_df.totemp)) / taz_df.totacre
-    taz_df["areatype"] = pd.cut(
-        taz_df.density,
-        bins=[0, 6, 30, 55, 100, 300, np.inf],
-        labels=[5, 4, 3, 2, 1, 0]
-    )
 
     buildings_df = buildings.to_frame(['zone_id',
                                        'building_type',
@@ -1531,6 +1524,24 @@ def travel_model_output(parcels, households, jobs, buildings,
     taz_df = add_population(taz_df, year, rc)
     taz_df.totpop = taz_df.hhpop + taz_df.gqpop
     taz_df = add_employment(taz_df, year, rc)
+    taz_df_pop_na = taz_df.loc[taz_df.totpop.isnull()]
+    print(taz_df_pop_na)
+    taz_df_emp_na = taz_df.loc[taz_df.totemp.isnull()]
+    print(taz_df_emp_na)
+    taz_df_acre_na = taz_df.loc[taz_df.totacre.isnull()]
+    print(taz_df_acre_na)
+    taz_df_zero_emp = taz_df.loc[taz_df.totemp == 0]
+    print(taz_df_zero_emp)
+    taz_df["density_pop"] = taz_df.totpop / taz_df.totacre
+    taz_df["density_pop"] = taz_df["density_pop"].fillna(0)
+    taz_df["density_emp"] = (2.5 * taz_df.totemp) / taz_df.totacre
+    taz_df["density_emp"] = taz_df["density_emp"].fillna(0)
+    taz_df["density"] = taz_df["density_pop"] + taz_df["density_emp"]
+    taz_df["areatype"] = pd.cut(
+        taz_df.density,
+        bins=[0, 6, 30, 55, 100, 300, np.inf],
+        labels=[5, 4, 3, 2, 1, 0]
+    )
     taz_df = add_age_categories(taz_df, year, rc)
     orca.add_table('taz_summary_1', taz_df)
 


### PR DESCRIPTION
Fix two errors in the TAZ-level `density` and `area_type` calculations in `travel_model_output()` in `summaries.py`:

- previously, the calculations occur before [adjusting population](https://github.com/BayAreaMetro/bayarea_urbansim/blob/eabb381eca88262a3e9968d1bf81e66b5e6e7fda/baus/summaries.py#L1437) and [employment](https://github.com/BayAreaMetro/bayarea_urbansim/blob/eabb381eca88262a3e9968d1bf81e66b5e6e7fda/baus/summaries.py#L1439) based on control totals, therefore TAZ-level densities are inconsistent with the final population and employment output.

- when a TAZ has 'na' employment, the previous calculation results in "na" employment density and eventually "0" density despite positive population density. So, fill na [here](https://github.com/BayAreaMetro/bayarea_urbansim/pull/273/files#diff-a06ab55985dd3575034bf5c24d0959c52471ec4756ea987c31ef859ee7616649R1530). 