### PR TITLE
fill na before calculating parcel_data_diff

### DIFF
--- a/baus/summaries.py
+++ b/baus/summaries.py
@@ -1418,6 +1418,10 @@ def parcel_summary(parcels, buildings, households, jobs,
             if col in ["x", "y", "first_building_type", "juris", join_col]:
                 continue
 
+            # fill na with 0 for parcels with no building in either base year or current year
+            df[col].fillna(0, inplace=True)
+            df2[col].fillna(0, inplace=True)
+            
             df[col] = df[col] - df2[col]
 
         df.to_csv(


### PR DESCRIPTION
https://app.asana.com/0/0/1199928036190368/f
When parcels are joined to buildings, NaNs appear where there are no buildings. This makes any diffs or other math done with those values also return NaN, instead of returning a value. 
We'll want to fillna(), starting with residential units in the parcel_data/parcel_data_diff. This came out of [✓ Fix visualizer missing projects](https://app.asana.com/0/1182664067032345/1199704448464133)
This should also likely become a data requirement and a data check. NaNs in numeric data should be 0.