### PR TITLE
Create consistent model runs

### DIFF
--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -592,7 +592,7 @@ def manual_edits():
 @orca.table(cache=True)
 def parcel_rejections():
     url = "https://forecast-feedback.firebaseio.com/parcelResults.json"
-    return pd.read_json(url, orient="index").set_index("geomId")
+    return pd.read_json(url, orient="index").reset_index()
 
 
 def reprocess_dev_projects(df):

--- a/baus/variables.py
+++ b/baus/variables.py
@@ -638,15 +638,10 @@ def newest_building(parcels, buildings):
 # this returns the set of parcels which have been marked as
 # disapproved by "the button" - only equals true when disallowed
 @orca.column('parcels', cache=True)
-def manual_nodev(parcel_rejections, parcels):
-    df1 = parcels.to_frame(['x', 'y']).dropna(subset=['x', 'y'])
-    df2 = parcel_rejections.to_frame(['lng', 'lat'])
-    df2 = df2[parcel_rejections.state == "denied"]
-    df2 = df2[["lng", "lat"]]  # need to change the order
-    ind = nearest_neighbor(df1, df2)
-
-    s = pd.Series(False, parcels.index)
-    s.loc[ind.flatten()] = True
+def manual_nodev(parcel_rejections):
+    df = parcel_rejections.to_frame()
+    df = df[df.state == "denied"]
+    s = df.parcelId
     return s.astype('int')
 
 


### PR DESCRIPTION
The goal of this PR was to identify any causes of run-to-run variation in model results. While some BAUS sub-models are stochastic, when the random seed is set, model results should be identical. 

The following cause of variation were found and remedied: BAUS reads in a json file that specifies parcel to mark as `nodev`. A nearest neighbor function was being used to translate between this file and the corresponding Parcel ID in the BAUS parcels table. This function sometimes returned the full set of locations from the json file but other times dropped most of them. Because the json table inherently contains a Parcel ID column, the nearest neighbor step was removed from the model run. It was confirmed that the json Parcel IDs and the nearest neighbor Parcel IDs match one another.

To test the changes, the run logs of four BAUS runs were compared. The logs were identical indicting that each BAUS model step was producing the same results.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203192635155037