### PR TITLE
Remove slacker dependency

### DIFF
--- a/baus-env-2023.yml
+++ b/baus-env-2023.yml
@@ -20,3 +20,4 @@ dependencies:
   - urbansim=3.2
   - urbansim_defaults=0.2
   - pyyaml<6.0
+  - slack_sdk

--- a/baus.py
+++ b/baus.py
@@ -414,7 +414,7 @@ if SLACK and MODE == "simulation":
     except SlackApiError as e:
         assert e.response["ok"] is False
         assert e.response["error"]  
-    print(f"Slack Channel Connection Error: {e.response['error']}")
+        print(f"Slack Channel Connection Error: {e.response['error']}")
 
 try:
     run_models(MODE)

--- a/baus/utils.py
+++ b/baus/utils.py
@@ -10,7 +10,7 @@ from urbansim.developer.developer import Developer as dev
 import itertools as it
 # for urbanforecast.com visualizer
 if "URBANSIM_SLACK" in os.environ:
-    import boto3
+    #import boto3
     import time
     import requests
     import json


### PR DESCRIPTION
This small PR removes the [slacker library](https://github.com/os/slacker/) dependency, used for posting to the agency slack channel. The library is archived. We replace it with the [official Python Slack SDK](https://github.com/slackapi/python-slack-sdk) instead.

`slacker` was used in `baus.py`. A separate import of `boto3` has been removed in `baus/utils.py`