### PR TITLE
Output summaries for 2025 in addition to 2020, 2035, 2050

### DIFF
--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -47,17 +47,6 @@ def outputs_dir(run_setup):
 def viz_dir(run_setup):
     return os.path.join(run_setup['viz_dir'])
 
-@orca.injectable('sqft_per_job_adj_file', cache=True)
-def sqft_per_job_adj_file(run_setup):
-    
-    adj_file = run_setup['sqft_per_job_adj_file']
-    return adj_file
-
-@orca.injectable('exog_sqft_per_job_adj_file', cache=True)
-def exog_sqft_per_job_adj_file(run_setup):
-    
-    adj_file = run_setup['exog_sqft_per_job_adj_file']
-    return adj_file
 
 @orca.injectable('emp_reloc_rates_adj_file', cache=True)
 def emp_reloc_rates_adj_file(run_setup):
@@ -886,13 +875,18 @@ def superdistricts_geography():
 
 
 @orca.table(cache=True)
-def sqft_per_job_adjusters(): 
-    return pd.read_csv(os.path.join(misc.configs_dir(), "adjusters", orca.get_injectable("sqft_per_job_adj_file")), index_col="number")
+def sqft_per_job_adjusters(run_setup):
+    # Add if statement in case the file is not specified
+    if run_setup["sqft_per_job_adj_file"] is not None:
+        return pd.read_csv(os.path.join(misc.configs_dir(), "adjusters", run_setup["sqft_per_job_adj_file"]), index_col="number")
 
 
 @orca.table(cache=True)
-def exog_sqft_per_job_adjusters(): 
-    return pd.read_csv(os.path.join(misc.configs_dir(), "adjusters", orca.get_injectable("exog_sqft_per_job_adj_file")), index_col="number")
+def exog_sqft_per_job_adjusters(run_setup):
+    # Add if statement in case the file is not specified
+    if run_setup['exog_sqft_per_job_adj_file'] is not None:
+        return pd.read_csv(os.path.join(misc.configs_dir(), "adjusters", run_setup['exog_sqft_per_job_adj_file']), index_col="number")
+
 
 @orca.table(cache=True)
 def telecommute_sqft_per_job_adjusters(run_setup): 

--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -210,8 +210,8 @@ def initial_summary_year(run_setup):
 
 
 @orca.injectable()
-def interim_summary_year():
-    return 2035
+def interim_summary_years():
+    return [2025, 2035]
 
 
 @orca.injectable()

--- a/baus/summaries/core_summaries.py
+++ b/baus/summaries/core_summaries.py
@@ -6,10 +6,10 @@ import pandas as pd
 
 
 @orca.step()
-def parcel_summary(run_name, parcels, buildings, households, jobs, year, initial_summary_year, interim_summary_year, final_year):
+def parcel_summary(run_name, parcels, buildings, households, jobs, year, initial_summary_year, final_year, interim_summary_years):
 
-    if year not in [initial_summary_year, interim_summary_year, final_year]:
-         return
+    if year not in [initial_summary_year, final_year] + interim_summary_years:
+        return
 
     df = parcels.to_frame(["geom_id", "x", "y"])
     # add building data for parcels
@@ -70,9 +70,9 @@ def parcel_growth_summary(year, run_name, initial_summary_year, final_year):
 
 
 @orca.step()
-def building_summary(run_name, parcels, buildings, year, initial_summary_year, final_year, interim_summary_year):
+def building_summary(run_name, parcels, buildings, year, initial_summary_year, final_year, interim_summary_years):
 
-    if year not in [initial_summary_year, interim_summary_year, final_year]:
+    if year not in [initial_summary_year, final_year] + interim_summary_years:
         return
 
     df = orca.merge_tables('buildings',

--- a/baus/summaries/geographic_summaries.py
+++ b/baus/summaries/geographic_summaries.py
@@ -8,10 +8,10 @@ from baus import datasources
 
 @orca.step()
 def geographic_summary(parcels, households, jobs, buildings, year, superdistricts_geography,
-                       initial_summary_year, interim_summary_year, final_year, run_name):  
+                       initial_summary_year, final_year, interim_summary_years, run_name):  
 
     # Commenting this out so we get geographic summaries for all years - DSL 2023-08-31
-    # if year not in [initial_summary_year, interim_summary_year, final_year]:
+    # if year not in [initial_summary_year, final_year] + interim_summary_years:
     #      return
 
     households_df = orca.merge_tables('households', [parcels, buildings, households],

--- a/baus/summaries/travel_model_summaries.py
+++ b/baus/summaries/travel_model_summaries.py
@@ -223,11 +223,11 @@ def adjust_hhkids(df, year, rdf, total_hh):
 @orca.step()
 def taz1_summary(parcels, households, jobs, buildings, zones, maz, year, base_year_summary_taz, taz_geography, 
                  tm1_taz1_forecast_inputs, tm1_tm2_maz_forecast_inputs, tm1_tm2_regional_demographic_forecast, 
-                 tm1_tm2_regional_controls, initial_summary_year, interim_summary_year, final_year, run_name):
+                 tm1_tm2_regional_controls, initial_summary_year, final_year, interim_summary_years, run_name):
     
     # Commenting this out so we get taz1 summaries for every year.
     # It's about 90 seconds a pop so not great, not terrible
-    # if year not in [initial_summary_year, interim_summary_year, final_year]:
+    # if year not in [initial_summary_year, final_year] + interim_summary_years:
     #     return
 
     # (1) add relevant geographies to TAZ summaries
@@ -406,10 +406,10 @@ def taz1_growth_summary(year, initial_summary_year, final_year, run_name, buildi
 @orca.step()
 def maz_marginals(parcels, households, buildings, maz, year,
                   tm1_tm2_maz_forecast_inputs, tm1_tm2_regional_demographic_forecast, initial_summary_year, 
-                  interim_summary_year, final_year, run_name):
+                  final_year, interim_summary_years, run_name):
     
-    if year not in [initial_summary_year, interim_summary_year, final_year]:
-         return
+    if year not in [initial_summary_year, final_year] + interim_summary_years:
+        return
     
     # (1) intiialize maz dataframe
     maz_m = maz.to_frame(['TAZ', 'county_name'])
@@ -447,10 +447,10 @@ def maz_marginals(parcels, households, buildings, maz, year,
 
 @orca.step()
 def maz_summary(parcels, jobs, households, buildings, maz, year, tm2_emp27_employment_shares, 
-                tm1_tm2_regional_controls, initial_summary_year, interim_summary_year, final_year, run_name):
+                tm1_tm2_regional_controls, initial_summary_year, final_year, interim_summary_years, run_name):
     
-    if year not in [initial_summary_year, interim_summary_year, final_year]:
-         return
+    if year not in [initial_summary_year, final_year] + interim_summary_years:
+        return
 
     # (1) intiialize maz dataframe
     maz_df = maz.to_frame(['TAZ', 'county_name'])
@@ -577,10 +577,10 @@ def maz_growth_summary(year, initial_summary_year, final_year, run_name):
 
 @orca.step()
 def taz2_marginals(tm2_taz2_forecast_inputs, tm1_tm2_regional_demographic_forecast, tm1_tm2_regional_controls, 
-                   year, initial_summary_year, interim_summary_year, final_year, run_name):
+                   year, initial_summary_year, final_year, interim_summary_years, run_name):
     
-    if year not in [initial_summary_year, interim_summary_year, final_year]:
-         return
+    if year not in [initial_summary_year, final_year] + interim_summary_years:
+        return
 
     # (1) bring in taz2 dataframe
     taz2 = pd.DataFrame(index=tm2_taz2_forecast_inputs.index)
@@ -630,10 +630,10 @@ def taz2_marginals(tm2_taz2_forecast_inputs, tm1_tm2_regional_demographic_foreca
 
 @orca.step()
 def county_marginals(tm2_occupation_shares, year, initial_summary_year, 
-                     interim_summary_year, final_year, run_name):
+                     final_year, interim_summary_years, run_name):
 
-    if year not in [initial_summary_year, interim_summary_year, final_year]:
-         return
+    if year not in [initial_summary_year, final_year] + interim_summary_years:
+        return
 
     maz = orca.get_table("maz_summary_df").to_frame()
     taz2 = orca.get_table("taz2_summary_df").to_frame()
@@ -671,10 +671,10 @@ def county_marginals(tm2_occupation_shares, year, initial_summary_year,
     
 
 @orca.step()
-def region_marginals(year, initial_summary_year, interim_summary_year, final_year, run_name):
+def region_marginals(year, initial_summary_year, final_year, interim_summary_years, run_name):
 
-    if year not in [initial_summary_year, interim_summary_year, final_year]:
-         return
+    if year not in [initial_summary_year, final_year] + interim_summary_years:
+        return
     
     # (1) get group quarters from MAZ summaries
     maz_marginals_df = orca.get_table("maz_marginals_df").to_frame()

--- a/run_setup_PBA50Plus_DraftBlueprint.yaml
+++ b/run_setup_PBA50Plus_DraftBlueprint.yaml
@@ -26,11 +26,11 @@ viz_dir: 'M:/urban_modeling/baus/PBA50Plus/BAUS_Visualizer_PBA50Plus_Files'
 
 
 # CORE CONFIGS
-elcm_spec_file: elcm.yaml
+elcm_spec_file: "elcm.yaml"
 
 
 # EXOGENOUS FORCES
-exog_sqft_per_job_adj_file: sqft_per_job_adjusters_exogenous.csv
+exog_sqft_per_job_adj_file: "sqft_per_job_adjusters_exogenous.csv"
 # must be set to false if sqft per job adjusters or telecommute strategy is enabled
 use_exogenous_sqft_per_job_adjusters: True
 # used for exogenous block to denote if exogenous adjusters should be applied to office only
@@ -38,7 +38,7 @@ job_density_adj_office_only: False
 
 
 # MODEL ADJUSTERS
-emp_reloc_rates_adj_file: employment_relocation_rates_overwrites.csv
+emp_reloc_rates_adj_file: "employment_relocation_rates_overwrites.csv"
 employment_relocation_rates_adjusters: True
 sqft_per_job_adj_file: 
 # must be set to false if sqft per job exogenous forces or telecommute are enabled

--- a/run_setup_PBA50Plus_DraftBlueprint.yaml
+++ b/run_setup_PBA50Plus_DraftBlueprint.yaml
@@ -9,7 +9,7 @@ run_name: "PBA50Plus_DraftBlueprint"
 
 # PATHS FOR INPUTS AND OUTPUTS
 inputs_dir: 'M:/urban_modeling/baus/BAUS Inputs'
-outputs_dir: 'M:/urban_modeling/baus/PBA50Plus/PBA50Plus_NP_InitialRun/outputs'
+outputs_dir: 'M:/urban_modeling/baus/PBA50Plus/PBA50Plus_DBP_InitialRun/outputs'
 
 # OPTIONAL RUN VALIDATION
 run_simulation_validation: True 
@@ -31,7 +31,7 @@ elcm_spec_file: elcm.yaml
 
 # EXOGENOUS FORCES
 exog_sqft_per_job_adj_file: sqft_per_job_adjusters_exogenous.csv
-# must be set to false is sqft per job adjusters or telecommute strategy is enabled
+# must be set to false if sqft per job adjusters or telecommute strategy is enabled
 use_exogenous_sqft_per_job_adjusters: True
 # used for exogenous block to denote if exogenous adjusters should be applied to office only
 job_density_adj_office_only: False
@@ -51,7 +51,7 @@ residential_vacancy_rate_mods: True
 
 
 # REGIONAL CONTROL FILES
-household_controls_file: "household_controls_PBA50Plus_DBP.csv"
+household_controls_file: "household_controls_PBA50Plus_DBP_UBI2030.csv"
 employment_controls_file: "employment_controls_PBA50Plus_NP_DBP.csv"
 
 
@@ -62,8 +62,8 @@ use_pipeline_filters: False
 
 
 # ZONING FILES
-zoning_lookup_file: "2024_02_09_zoning_lookup_hybrid_he_pba50plus.csv"
-zoning_file: "2024_02_09_zoning_parcels_hybrid_he_pba50plus.csv"
+zoning_lookup_file: "2024_04_09_zoning_lookup_hybrid_he_MS_pba50plus.csv"
+zoning_file: "2024_04_09_zoning_parcels_hybrid_he_MS_pba50plus.csv"
 
 
 # SEA LEVEL RISE
@@ -106,7 +106,7 @@ dev_pipeline_strategies:
 
 
 # GROWTH GEOGRAPHY INPUT FILE
-parcels_geography_file: "2021_02_25_parcels_geography.csv"
+parcels_geography_file: "parcels_geography_2024_02_14.csv"
 parcels_geography_cols: ["gg_id", "pda_id", "tra_id", "sesit_id", "coc_id", "ppa_id", "cat_id"]
 
 

--- a/run_setup_PBA50Plus_NoProject.yaml
+++ b/run_setup_PBA50Plus_NoProject.yaml
@@ -31,7 +31,7 @@ elcm_spec_file: elcm.yaml
 
 # EXOGENOUS FORCES
 exog_sqft_per_job_adj_file: sqft_per_job_adjusters_exogenous.csv
-# must be set to false is sqft per job adjusters or telecommute strategy is enabled
+# must be set to false if sqft per job adjusters or telecommute strategy is enabled
 use_exogenous_sqft_per_job_adjusters: True
 # used for exogenous block to denote if exogenous adjusters should be applied to office only
 job_density_adj_office_only: False
@@ -62,8 +62,8 @@ use_pipeline_filters: False
 
 
 # ZONING FILES
-zoning_lookup_file: "2024_02_09_zoning_lookup_hybrid_he_pba50plus.csv"
-zoning_file: "2024_02_09_zoning_parcels_hybrid_he_pba50plus.csv"
+zoning_lookup_file: "2024_04_09_zoning_lookup_hybrid_he_MS_pba50plus.csv"
+zoning_file: "2024_04_09_zoning_parcels_hybrid_he_MS_pba50plus.csv"
 
 
 # SEA LEVEL RISE
@@ -98,7 +98,7 @@ run_sb_743_strategy: True
 
 # PLAN STRATEGIES
 
-#DEVELOPMENT PIPELINE STRATEGIES
+# DEVELOPMENT PIPELINE STRATEGIES
 dev_pipeline_strategies:
    #- "EC2_development_pipeline_entries.csv"
    #- "EC6_development_pipeline_entries.csv"
@@ -106,7 +106,7 @@ dev_pipeline_strategies:
 
 
 # GROWTH GEOGRAPHY INPUT FILE
-parcels_geography_file: "2021_02_25_parcels_geography.csv"
+parcels_geography_file: "parcels_geography_2024_02_14.csv"
 parcels_geography_cols: ["gg_id", "pda_id", "tra_id", "sesit_id", "coc_id", "ppa_id", "cat_id"]
 
 

--- a/run_setup_PBA50Plus_NoProject.yaml
+++ b/run_setup_PBA50Plus_NoProject.yaml
@@ -26,11 +26,11 @@ viz_dir: 'M:/urban_modeling/baus/PBA50Plus/BAUS_Visualizer_PBA50Plus_Files'
 
 
 # CORE CONFIGS
-elcm_spec_file: elcm.yaml
+elcm_spec_file: "elcm.yaml"
 
 
 # EXOGENOUS FORCES
-exog_sqft_per_job_adj_file: sqft_per_job_adjusters_exogenous.csv
+exog_sqft_per_job_adj_file: "sqft_per_job_adjusters_exogenous.csv"
 # must be set to false if sqft per job adjusters or telecommute strategy is enabled
 use_exogenous_sqft_per_job_adjusters: True
 # used for exogenous block to denote if exogenous adjusters should be applied to office only
@@ -38,7 +38,7 @@ job_density_adj_office_only: False
 
 
 # MODEL ADJUSTERS
-emp_reloc_rates_adj_file: employment_relocation_rates_overwrites.csv
+emp_reloc_rates_adj_file: "employment_relocation_rates_overwrites.csv"
 employment_relocation_rates_adjusters: True
 sqft_per_job_adj_file: 
 # must be set to false if sqft per job exogenous forces or telecommute are enabled


### PR DESCRIPTION
We need 2025 summaries - specifically core->parcel and geographic->county - so we can linearly interpolate between 2020 and 2025 to establish Draft Blueprint "initial year" metrics. (We're going to use an interpolated No Project 2023 year as the "initial year": https://app.asana.com/0/0/1207031046044722/f )

This small PR takes advantage of `interim_summary_year` which already existed, changing it from an int to an array of two ints (2025 and 2035) and updating how it is used downstream.