### PR TITLE
Use PARCEL_ID to fix mangled geom_ids on initial read

### DIFF
--- a/baus/datasources.py
+++ b/baus/datasources.py
@@ -625,6 +625,10 @@ def get_dev_projects_table(parcels, run_setup):
 #         df = pipeline_filtering(df, filter_criteria)
 #         print('Records in pipeline table - post-filter: ',df.shape[0])
 
+    # geom_id got mangled at some point, so we refresh it via lookup from PARCEL_ID.
+    # TODO We should probably deprecate geom_id (which has no extra information over parcel_id) throughout BAUS
+    df['geom_id'] = parcel_id_to_geom_id(df['PARCEL_ID'])
+    
     df = reprocess_dev_projects(df)
 
     # Optionally - if flag set to use housing element pipeline, load that and append:


### PR DESCRIPTION
Quick update to datasources.py to overwrite the as-received `geom_id`s (which were mangled, probably in Excel, at some point) with freshly calculated `geom_id`s based on `PARCEL_ID`s.

Also, I didn't make these changes in utils.py but a couple things caught my eye there.
1. Why does geom_id_to_parcel_id return a DF but parcel_id_to_geom_id returns a Series? One or the other of the function names is misleading.
2. Another way to write parcel_id_to_geom_id would be like the following:
```
def parcel_id_to_geom_id(s, parcels):
    parcel_to_geom_dict = dict(zip(parcels.index, parcels.geom_id))
    return s.map(parcel_to_geom_dict)
```
I'm not sure this would work exactly as written (because I'm not sure whether `orca` tables have a `.index` attribute like `pandas` DataFrames do) but something like this seems cleaner than the way this function is written now.