### PR TITLE
Small fixes to summary functions

### DIFF
--- a/baus.py
+++ b/baus.py
@@ -348,7 +348,7 @@ def run_models(MODE):
 
                 "geographic_summary",
                 "geographic_growth_summary",
-
+                "parcel_transitions",
                 "taz1_summary",
                 "maz_marginals",
                 "maz_summary",

--- a/baus/variables.py
+++ b/baus/variables.py
@@ -143,7 +143,7 @@ def job_spaces(buildings):
 def vacant_job_spaces(buildings, jobs):
     s = jobs.building_id[jobs.building_id != -1]
     return buildings.job_spaces.sub(
-        s.value_counts(), fill_value=0).astype('int')
+        s.value_counts(), fill_value=0).clip(0).astype('int')
 
 
 @orca.column('buildings')


### PR DESCRIPTION
These items relate to https://github.com/BayAreaMetro/bayarea_urbansim/pull/368 but were inadvertently left out.

- add call to parcel_transitions function from `baus.py`
- add clip to `vacant_job_spaces` so we don't end up with negatives when there are more occupants than spaces